### PR TITLE
Feature/ecu battery module sync interface config

### DIFF
--- a/src/ecu_simulation/BatteryModule/include/InterfaceConfig.h
+++ b/src/ecu_simulation/BatteryModule/include/InterfaceConfig.h
@@ -20,6 +20,7 @@
 #include <linux/can/raw.h>
 #include <string.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 class SocketCanInterface
 {
@@ -32,6 +33,12 @@ private:
     void createLinuxVCanInterface();
     void deleteLinuxVCanInterface();
     void stopLinuxVCanInterface();
+/**
+ * @brief Set the socket to not block in the reading operation.
+ * 
+ * @return int 
+ */
+    int setSocketBlocking();
 /**
  * @brief Open a new socket and connect it to the vcan interface.
  * 

--- a/src/ecu_simulation/BatteryModule/include/InterfaceConfig.h
+++ b/src/ecu_simulation/BatteryModule/include/InterfaceConfig.h
@@ -12,7 +12,6 @@
 #ifndef INTERFACECONFIG_H
 #define INTERFACECONFIG_H
 
-#include <string>
 #include <linux/can.h>
 #include <net/if.h>
 #include <iostream> 
@@ -21,7 +20,6 @@
 #include <linux/can/raw.h>
 #include <string.h>
 #include <unistd.h>
-#include <syscall.h>
 
 class SocketCanInterface
 {
@@ -59,7 +57,6 @@ public:
     inline void callSystem(std::string& cmd) const;
 
     std::string& getInterfaceName();
-    void setInterfaceName(std::string& interfaceName);
     int getSocketFd() const;
 
     ~SocketCanInterface();

--- a/src/ecu_simulation/BatteryModule/include/InterfaceConfig.h
+++ b/src/ecu_simulation/BatteryModule/include/InterfaceConfig.h
@@ -21,18 +21,19 @@
 #include <linux/can/raw.h>
 #include <string.h>
 #include <unistd.h>
+#include <syscall.h>
 
 class SocketCanInterface
 {
 private:
     int _socketFd = -1;
     std::string _interfaceName;
-    struct can_frame _canFrame;
     struct sockaddr_can _addr;
     struct ifreq _ifr;
 
     void createLinuxVCanInterface();
     void deleteLinuxVCanInterface();
+    void stopLinuxVCanInterface();
 /**
  * @brief Open a new socket and connect it to the vcan interface.
  * 
@@ -40,6 +41,8 @@ private:
  * @return false for errors
  */
     bool openInterface();
+    void init();
+
 /**
  * @brief Close the owned socket and delete the vcan interface. Automatically called in destructor.
  * 
@@ -54,17 +57,6 @@ public:
  * @param[i] cmd 
  */
     inline void callSystem(std::string& cmd) const;
-/**
- * @brief Method used for connecting 2 vcan interfaces. 
- * When the source receives a message, the destination receives it too.
- * Simulates a can bus.
- * 
- * @param[i] sourceInterface 
- * @param[i] destinationInterface 
- */
-    void connectLinuxVCanInterfaces(std::string& sourceInterface, std::string& destinationInterface);
-
-    void init();
 
     std::string& getInterfaceName();
     void setInterfaceName(std::string& interfaceName);

--- a/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
+++ b/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
@@ -14,8 +14,6 @@ BatteryModule::BatteryModule() : moduleId(0x101),
     std::cout << "BatteryModule()" << std::endl;
     std::cout << "(BatteryModule)moduleId = " << this->moduleId << std::endl;
 #endif
-    /* Initialize the CAN interface */
-    canInterface.init();
 
     /* Initialize the Frame Receiver */
     frameReceiver = new ReceiveFrames(canInterface.getSocketFd(), moduleId);
@@ -34,8 +32,6 @@ BatteryModule::BatteryModule(int _interfaceNumber, int _moduleId) : moduleId(_mo
     std::cout << "BatteryModule(int interfaceNumber, int moduleId)" << std::endl;
     std::cout << "(BatteryModule)moduleId = " << this->moduleId << std::endl;
 #endif
-    /* Initialize the CAN interface */
-    canInterface.init();
 
     /* Initialize the Frame Receiver */
     frameReceiver = new ReceiveFrames(canInterface.getSocketFd(), moduleId);

--- a/src/ecu_simulation/BatteryModule/src/InterfaceConfig.cpp
+++ b/src/ecu_simulation/BatteryModule/src/InterfaceConfig.cpp
@@ -10,7 +10,6 @@
  */
 
 #include "../include/InterfaceConfig.h"
-#include "InterfaceConfig.h"
 
 SocketCanInterface::SocketCanInterface(const std::string& interfaceName) : _interfaceName{interfaceName}
 {
@@ -100,11 +99,6 @@ int SocketCanInterface::getSocketFd() const
 std::string& SocketCanInterface::getInterfaceName()
 {
     return _interfaceName;
-}
-
-void SocketCanInterface::setInterfaceName(std::string& interfaceName)
-{
-    _interfaceName = interfaceName;
 }
 
 void SocketCanInterface::init()

--- a/src/ecu_simulation/BatteryModule/src/InterfaceConfig.cpp
+++ b/src/ecu_simulation/BatteryModule/src/InterfaceConfig.cpp
@@ -10,18 +10,11 @@
  */
 
 #include "../include/InterfaceConfig.h"
+#include "InterfaceConfig.h"
 
 SocketCanInterface::SocketCanInterface(const std::string& interfaceName) : _interfaceName{interfaceName}
 {
-
-}
-
-int SocketCanInterface::getSocketFd() const
-{
-    if (_socketFd == -1) {
-        throw std::runtime_error("Socket FD is -1 (uninitialized)");
-    }
-    return _socketFd;
+    init();
 }
 
 void SocketCanInterface::callSystem(std::string& cmd) const
@@ -31,38 +24,13 @@ void SocketCanInterface::callSystem(std::string& cmd) const
         std::cout << cmd << " failed\n";
         /* exit(EXIT_FAILURE); */
     }
-    else
-    {
-        std::cout << cmd << " succesfull\n";
-    }
-}
-
-void SocketCanInterface::createLinuxVCanInterface()
-{
-    std::string cmd = "sudo ip link add " + _interfaceName + " type vcan";
-    callSystem(cmd);
-
-    cmd = "sudo ip link set " + _interfaceName + " up";
-    callSystem(cmd);
-}
-
-void SocketCanInterface::connectLinuxVCanInterfaces(std::string& sourceInterface, std::string& destinationInterface)
-{
-    std::string cmd = "cangw -A -s " + sourceInterface + " -d " + destinationInterface + " -e";
-    callSystem(cmd);
-}
-
-void SocketCanInterface::deleteLinuxVCanInterface()
-{
-    std::string cmd = "sudo ip link set " + _interfaceName + " down";
-    callSystem(cmd);
-
-    cmd = "sudo ip link delete " + _interfaceName + " type can";
-    callSystem(cmd);
 }
 
 bool SocketCanInterface::openInterface()
 {
+    std::string cmd = "sudo ip link set " + _interfaceName + " up";
+    callSystem(cmd);
+    
     /* Create the socket */
     _socketFd = socket(PF_CAN, SOCK_RAW, CAN_RAW);
     if(_socketFd < 0)
@@ -98,6 +66,7 @@ void SocketCanInterface::closeInterface()
             exit(EXIT_FAILURE);
         }
         deleteLinuxVCanInterface();
+        stopLinuxVCanInterface();
     }
     else
     {
@@ -105,6 +74,28 @@ void SocketCanInterface::closeInterface()
     }
 }
 
+void SocketCanInterface::createLinuxVCanInterface()
+{
+    std::string cmd = "sudo ip link add " + _interfaceName + " type vcan";
+    callSystem(cmd);
+}
+
+void SocketCanInterface::deleteLinuxVCanInterface()
+{
+    std::string cmd = "sudo ip link set " + _interfaceName + " down";
+    callSystem(cmd);
+}
+
+void SocketCanInterface::stopLinuxVCanInterface()
+{
+    std::string cmd = "sudo ip link delete " + _interfaceName + " type can";
+    callSystem(cmd);
+}
+
+int SocketCanInterface::getSocketFd() const
+{
+    return _socketFd;
+}
 
 std::string& SocketCanInterface::getInterfaceName()
 {

--- a/src/ecu_simulation/BatteryModule/src/InterfaceConfig.cpp
+++ b/src/ecu_simulation/BatteryModule/src/InterfaceConfig.cpp
@@ -25,6 +25,22 @@ void SocketCanInterface::callSystem(std::string& cmd) const
     }
 }
 
+int SocketCanInterface::setSocketBlocking()
+{
+    int flags = fcntl(_socketFd, F_GETFL, 0);
+    if (flags == -1) {
+        std::cerr << "Eroare la obtinerea flagurilor socket-ului: " << strerror(errno) << std::endl;
+        return 1;
+    }
+    // Set the O_NONBLOCK flag to make the socket non-blocking
+    flags |= O_NONBLOCK;
+    if (fcntl(_socketFd, F_SETFL, flags) == -1) 
+    {
+        std::cerr << "Error setting flags: " << strerror(errno) << std::endl;
+        return -1;
+    }
+}
+
 bool SocketCanInterface::openInterface()
 {
     std::string cmd = "sudo ip link set " + _interfaceName + " up";
@@ -52,6 +68,8 @@ bool SocketCanInterface::openInterface()
         std::cout<<"Error binding\n";
         return 1;
     }
+    setSocketBlocking();
+    
     return 0;
 }
 

--- a/src/ecu_simulation/BatteryModule/src/InterfaceConfig.cpp
+++ b/src/ecu_simulation/BatteryModule/src/InterfaceConfig.cpp
@@ -28,9 +28,10 @@ void SocketCanInterface::callSystem(std::string& cmd) const
 int SocketCanInterface::setSocketBlocking()
 {
     int flags = fcntl(_socketFd, F_GETFL, 0);
-    if (flags == -1) {
+    if (flags == -1) 
+    {
         std::cerr << "Eroare la obtinerea flagurilor socket-ului: " << strerror(errno) << std::endl;
-        return 1;
+        return -1;
     }
     // Set the O_NONBLOCK flag to make the socket non-blocking
     flags |= O_NONBLOCK;
@@ -39,6 +40,7 @@ int SocketCanInterface::setSocketBlocking()
         std::cerr << "Error setting flags: " << strerror(errno) << std::endl;
         return -1;
     }
+    return 1;
 }
 
 bool SocketCanInterface::openInterface()

--- a/src/ecu_simulation/BatteryModule/test/InterfaceConfigTest.cpp
+++ b/src/ecu_simulation/BatteryModule/test/InterfaceConfigTest.cpp
@@ -43,16 +43,6 @@ TEST_F(InterfaceConfigTest, GetInterfaceName)
     EXPECT_EQ(globalInterface.getInterfaceName(), globalInterfaceName);
 }
 
-TEST_F(InterfaceConfigTest, SetInterfaceName) 
-{
-    std::string expectedInterfaceName = "vcan2";
-    std::string previousInterfaceName = globalInterface.getInterfaceName();
-
-    globalInterface.setInterfaceName(expectedInterfaceName);
-
-    EXPECT_EQ(globalInterface.getInterfaceName(), expectedInterfaceName);
-}
-
 TEST_F(InterfaceConfigTest, SystemCall) 
 {
     std::string cmd = "wrong command";

--- a/src/ecu_simulation/BatteryModule/test/InterfaceConfigTest.cpp
+++ b/src/ecu_simulation/BatteryModule/test/InterfaceConfigTest.cpp
@@ -21,11 +21,21 @@ protected:
     };
 };
 
-TEST_F(InterfaceConfigTest, Constructor_ValidInterfaceName) 
+TEST_F(InterfaceConfigTest, ConstructorInterfaceNameSet) 
 {
     const std::string interfaceName = "vcan2";
     SocketCanInterface batteryInterface(interfaceName);
     EXPECT_EQ(batteryInterface.getInterfaceName(), interfaceName);
+}
+TEST_F(InterfaceConfigTest, ConstructorCreateInterface)
+{
+    
+    std::ostringstream output;
+    {
+        CoutRedirect guard(output.rdbuf());
+        auto interface = SocketCanInterface("vcan3");
+    }
+    EXPECT_EQ(output.str(), "vcan3 initialised\n");
 }
 
 TEST_F(InterfaceConfigTest, GetInterfaceName) 
@@ -46,41 +56,30 @@ TEST_F(InterfaceConfigTest, SetInterfaceName)
 TEST_F(InterfaceConfigTest, SystemCall) 
 {
     std::string cmd = "wrong command";
-    std::string expectedOutput = cmd + " failed\n";
+    std::string cmdFailedOutput = cmd + " failed\n";
 
     std::ostringstream output;
     {
         CoutRedirect guard(output.rdbuf());
         globalInterface.callSystem(cmd);
     }
-    EXPECT_EQ(output.str(), expectedOutput);
+    EXPECT_EQ(output.str(), cmdFailedOutput);
 
     cmd = "pwd";
-    expectedOutput = cmd + " succesfull\n";
     output.str("");
     output.clear();
     {
         CoutRedirect guard(output.rdbuf());
         globalInterface.callSystem(cmd);
     }
-    EXPECT_EQ(output.str(), expectedOutput);
-}
-
-TEST_F(InterfaceConfigTest, InitInterface) 
-{
-    auto interface = SocketCanInterface("vcan1");
-
+    EXPECT_NE(output.str(), cmdFailedOutput);
 }
 
 TEST_F(InterfaceConfigTest, GetSocketFd) 
 {
     auto interface = SocketCanInterface("vcan1");
     int defaultFd = -1;
-
-    EXPECT_THROW(interface.getSocketFd(), std::runtime_error);
     
-    interface.init();
-    EXPECT_NO_THROW(interface.getSocketFd());
     EXPECT_NE(interface.getSocketFd(), defaultFd);
 }
 
@@ -91,7 +90,8 @@ TEST_F(InterfaceConfigTest, DestructorTest)
     {
         CoutRedirect guard(output.rdbuf());
         auto interface = SocketCanInterface(interfaceName);
+        output.clear();
     }
-    std::string expectedOutput = "Can't close socket with fd = -1";
-    EXPECT_EQ(output.str(), expectedOutput);
+    std::string failOutput = "Can't close socket with fd = -1";
+    EXPECT_NE(output.str(), failOutput);
 }


### PR DESCRIPTION
Synchronized the ECU Interface config class to contain the same functionalities as MCU.
Changes made:
-before: init() function called after constructor, now it is called in the constructor
-removed methods and attributes that are not used
-sepparated the creation of vcan from the opening of the vcan (2 methods)
-sepparated deletion of vcan from closing of vcan (2 methods)