### PR TITLE
add logger for ecu battery

### DIFF
--- a/src/ecu_simulation/BatteryModule/include/BatteryModule.h
+++ b/src/ecu_simulation/BatteryModule/include/BatteryModule.h
@@ -29,6 +29,7 @@
 #include "InterfaceConfig.h"
 #include "ReceiveFrames.h"
 #include "GenerateFrames.h"
+#include "BatteryModuleLogger.h"
 
 class BatteryModule
 {

--- a/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
+++ b/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
@@ -1,5 +1,11 @@
 #include "../include/BatteryModule.h"
 
+#ifdef TESTING
+    Logger batteryModuleLogger();
+#else
+    Logger batteryModuleLogger("batteryModuleLogger", "logs/batteryModuleLogger.log");
+#endif
+
 /** Constructor - initializes the BatteryModule with default values,
  * sets up the CAN interface, and prepares the frame receiver. */
 BatteryModule::BatteryModule() : moduleId(0x101),

--- a/src/utils/Logger/include/Logger.h
+++ b/src/utils/Logger/include/Logger.h
@@ -104,6 +104,16 @@ public:
     ~Logger();
 };
 
+// #define TESTING 
+#define CONSOLE_LOGGER getConsoleLogger()
+#define FILE_LOGGER getFileLogger()
+
+#ifdef TESTING
+#define GET_LOGGER() CONSOLE_LOGGER
+#else
+#define GET_LOGGER() FILE_LOGGER
+#endif
+
 /* LOGGING CAN BE TURNED OFF AT COMPILE TIME, BUT USAGE OF MACROS IS NEEDED IN ORDER TO WORK*/
 #define LOG_TRACE(logger, ...) SPDLOG_LOGGER_TRACE(logger, __VA_ARGS__)
 #define LOG_DEBUG(logger, ...) SPDLOG_LOGGER_DEBUG(logger, __VA_ARGS__)


### PR DESCRIPTION
Prepared logger class to be used in the ecu_battery module.
When testing, the logging will be redirected to the console, otherwise to file.
Only one logger used per ECU.

Testing mode is enabled/disabled in the Logger.h file