### PR TITLE
ReadDataByIdentifier service

### DIFF
--- a/src/ecu_simulation/BatteryModule/Makefile
+++ b/src/ecu_simulation/BatteryModule/Makefile
@@ -2,10 +2,10 @@
 CFLAGS = -g -Wall -pthread -I./include -I./src -I../../utils/include -I../../utils/src
 CFLAGSTST = -std=c++17 -I/include -DUNIT_TESTING_MODE
 LDFLAGS = -lspdlog
-CFLAGSTST2 = -lgtest -lgtest_main -pthread -fprofile-arcs -ftest-coverage
+CFLAGSTST2 = -lgtest -lgtest_main -pthread
 #Sources files
-SRCS = src/main.cpp src/BatteryModule.cpp ../../utils/src/GenerateFrames.cpp src/HandleFrames.cpp ../../utils/src/CreateInterface.cpp src/ReceiveFrames.cpp
-
+SRCS = src/main.cpp src/BatteryModule.cpp ../../utils/src/GenerateFrames.cpp src/HandleFrames.cpp ../../utils/src/CreateInterface.cpp src/ReceiveFrames.cpp ../../uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp ../../mcu/src/HandleFrames.cpp ../../mcu/src/ReceiveFrames.cpp ../../mcu/src/MCUModule.cpp
+SRCSTEST = src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp ../../uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp ../../mcu/src/HandleFrames.cpp ../../mcu/src/ReceiveFrames.cpp ../../mcu/src/MCUModule.cpp
 #Object files
 OBJS = $(patsubst ../utils/src/%.cpp src/%.cpp, obj/%.o, $(SRCS))
 OBJS:= $(OBJS) obj/Logger.o
@@ -21,7 +21,7 @@ $(FINAL): $(OBJS)
 	$(CXX) $(CFLAGS) -o $(FINAL) $(OBJS) ${LDFLAGS}
 $(OBJ_DIR):
 	mkdir -p $(OBJ_DIR)
-$(OBJ_DIR)/main.o: src/main.cpp include/BatteryModule.h include/ReceiveFrames.h include/HandleFrames.h include/GenerateFrames.h ../../utils/include/CreateInterface.h ../../utils/include/Logger.h include/BatteryModuleLogger.h
+$(OBJ_DIR)/main.o: src/main.cpp include/BatteryModule.h include/ReceiveFrames.h include/HandleFrames.h include/GenerateFrames.h ../../utils/include/CreateInterface.h ../../utils/include/Logger.h include/BatteryModuleLogger.h ../../uds/read_data_by_identifier/include/ReadDataByIdentifier.h ../../mcu/include/HandleFrames.h ../../mcu/include/ReceiveFrames.h ../../mcu/include/MCUModule.h
 	$(CXX) $(CFLAGS) -c src/main.cpp -o $(OBJ_DIR)/main.o
 $(OBJ_DIR)/BatteryModule.o: src/BatteryModule.cpp
 	$(CXX) $(CFLAGS) -c src/BatteryModule.cpp -o $(OBJ_DIR)/BatteryModule.o
@@ -50,32 +50,32 @@ allTests: handleTest receiveTest generateTest createInterfaceTest batteryModuleT
 # BatteryModule Unit tests
 batteryModuleTest: BatteryModuleTest
 BatteryModuleTest: test/BatteryModuleTest.cpp src/BatteryModule.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -o test/BatteryModuleTest test/BatteryModuleTest.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -o test/BatteryModuleTest test/BatteryModuleTest.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 
 # HandleFrames Unit tests
 handleTest: HandleFrames_test
 HandleFrames_test: test/HandleFrames_test.cpp src/HandleFrames.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -o test/HandleFrames_test test/HandleFrames_test.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -o test/HandleFrames_test test/HandleFrames_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 
 # ReceiveFrames Unit tests
 receiveTest: ReceiveFrames_test
 ReceiveFrames_test: test/ReceiveFramesTest.cpp src/ReceiveFrames.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -o test/ReceiveFramesTest test/ReceiveFramesTest.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -o test/ReceiveFramesTest test/ReceiveFramesTest.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 
 # GenerateFrames Unit tests
 generateTest: GenerateFrames_test
 GenerateFrames_test: ../../utils/test/GenerateFramesTest.cpp ../../utils/src/GenerateFrames.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -o ../../utils/test/GenerateFramesTest ../../utils/test/GenerateFramesTest.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -o ../../utils/test/GenerateFramesTest ../../utils/test/GenerateFramesTest.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 
 # CreateInterface Unit tests
 createInterfaceTest: CreateInterface_test
 CreateInterface_test: ../../utils/test/CreateInterface_test.cpp ../../utils/src/CreateInterface.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -o ../../utils/test/CreateInterface_test ../../utils/test/CreateInterface_test.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -o ../../utils/test/CreateInterface_test ../../utils/test/CreateInterface_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 
 # BatteryModule Coverage
 batteryModuleCoverage: BatteryModuleCoverage
 BatteryModuleCoverage: test/BatteryModuleTest.cpp src/BatteryModule.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/BatteryModuleTest test/BatteryModuleTest.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/BatteryModuleTest test/BatteryModuleTest.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./test/BatteryModuleTest
 	mkdir -p coverage/out_BatteryModule
 	gcov -o . src/BatteryModule.cpp
@@ -92,7 +92,7 @@ BatteryModuleCoverage: test/BatteryModuleTest.cpp src/BatteryModule.cpp
 # HandleFrames Coverage
 handleCoverage: HandleFramesCoverage
 HandleFramesCoverage: test/HandleFrames_test.cpp src/HandleFrames.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/HandleFrames_test test/HandleFrames_test.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/HandleFrames_test test/HandleFrames_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./test/HandleFrames_test
 	mkdir -p coverage/out_HandleFrames
 	gcov -o . src/HandleFrames.cpp
@@ -109,7 +109,7 @@ HandleFramesCoverage: test/HandleFrames_test.cpp src/HandleFrames.cpp
 # ReceiveFrames Coverage
 receiveCoverage: ReceiveFramesCoverage
 ReceiveFramesCoverage: test/ReceiveFramesTest.cpp src/ReceiveFrames.cpp
-	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/ReceiveFramesTest test/ReceiveFramesTest.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/ReceiveFramesTest test/ReceiveFramesTest.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./test/ReceiveFramesTest
 	mkdir -p coverage/out_ReceiveFrames
 	gcov -o . src/ReceiveFrames.cpp
@@ -126,7 +126,7 @@ ReceiveFramesCoverage: test/ReceiveFramesTest.cpp src/ReceiveFrames.cpp
 # generateFrames Coverage
 generateCoverage: GenerateFramesCoverage
 GenerateFramesCoverage: ../../utils/test/GenerateFramesTest.cpp ../../utils/src/GenerateFrames.cpp
-	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../../utils/test/GenerateFramesTest ../../utils/test/GenerateFramesTest.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../../utils/test/GenerateFramesTest ../../utils/test/GenerateFramesTest.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./test/GenerateFramesTest
 	mkdir -p coverage/out_GenerateFrames
 	gcov -o . ../../utils/src/GenerateFrames.cpp
@@ -143,7 +143,7 @@ GenerateFramesCoverage: ../../utils/test/GenerateFramesTest.cpp ../../utils/src/
 # CreateInterface Coverage
 createInterfaceCoverage: CreateInterfaceCoverage
 CreateInterfaceCoverage: ../../utils/test/CreateInterface_test.cpp ../../utils/src/CreateInterface.cpp
-	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../../utils/test/CreateInterface_test ../../utils/test/CreateInterface_test.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../../utils/test/CreateInterface_test ../../utils/test/CreateInterface_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./../../utils/test/CreateInterface_test
 	mkdir -p coverage/out_CreateInterface
 	gcov -o . ../../utils/src/CreateInterface.cpp
@@ -160,35 +160,35 @@ CreateInterfaceCoverage: ../../utils/test/CreateInterface_test.cpp ../../utils/s
 allCoverage: BatteryModule_coverage HandleFrames_coverage ReceiveFrames_coverage GenerateFrames_coverage CreateInterface_coverage
 
 BatteryModule_coverage:
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/BatteryModuleTest test/BatteryModuleTest.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/BatteryModuleTest test/BatteryModuleTest.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./test/BatteryModuleTest
 	mkdir -p coverage/out_BatteryModule
 	gcov -o . src/BatteryModule.cpp
 	mv BatteryModule.cpp.gcov coverage/out_BatteryModule
 
 HandleFrames_coverage:
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/HandleFrames_test test/HandleFrames_test.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/HandleFrames_test test/HandleFrames_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./test/HandleFrames_test
 	mkdir -p coverage/out_HandleFrames
 	gcov -o . src/HandleFrames.cpp
 	mv HandleFrames.cpp.gcov coverage/out_HandleFrames
 
 ReceiveFrames_coverage:
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/ReceiveFramesTest test/ReceiveFramesTest.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/ReceiveFramesTest test/ReceiveFramesTest.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./test/ReceiveFramesTest
 	mkdir -p coverage/out_ReceiveFrames
 	gcov -o . src/ReceiveFrames.cpp
 	mv ReceiveFrames.cpp.gcov coverage/out_ReceiveFrames
 
 GenerateFrames_coverage:
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../../utils/test/GenerateFrames_Test ../../utils/test/GenerateFrames_Test.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../../utils/test/GenerateFrames_Test ../../utils/test/GenerateFrames_Test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./test/GenerateFrames_Test
 	mkdir -p coverage/out_GenerateFrames
 	gcov -o . ../../utils/src/GenerateFrames.cpp
 	mv GenerateFrames.cpp.gcov coverage/out_GenerateFrames
 
 CreateInterface_coverage:
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./../utils/test/CreateInterface_test
 	mkdir -p coverage/out_CreateInterface
 	gcov -o . ../../utils/src/CreateInterface.cpp

--- a/src/ecu_simulation/BatteryModule/include/BatteryModule.h
+++ b/src/ecu_simulation/BatteryModule/include/BatteryModule.h
@@ -42,6 +42,13 @@ private:
     ReceiveFrames* frameReceiver;
 
 public:
+    /* Variable to store ecu data */
+    std::unordered_map<uint16_t, std::vector<uint8_t>> ecu_data = {
+        {0x01A0, {0}},  /* Energy Level */
+        {0x01B0, {0}},  /* Voltage */
+        {0x01C0, {0}},  /* Percentage */
+        {0x01D0, {0}}   /* State of Charge */
+    };
     /**
      * @brief Default constructor for Battery Module object.
      */
@@ -129,5 +136,6 @@ public:
      */
     std::string getLinuxBatteryState();
 };
+extern BatteryModule battery;
 
 #endif

--- a/src/ecu_simulation/BatteryModule/include/HandleFrames.h
+++ b/src/ecu_simulation/BatteryModule/include/HandleFrames.h
@@ -27,6 +27,7 @@
 #include <thread>
 #include <sstream>
 #include "../include/BatteryModuleLogger.h"
+#include "../../../uds/read_data_by_identifier/include/ReadDataByIdentifier.h"
 
 class HandleFrames 
 {

--- a/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
+++ b/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
@@ -5,7 +5,7 @@ Logger batteryModuleLogger;
 #else
 Logger batteryModuleLogger("batteryModuleLogger", "logs/batteryModuleLogger.log");
 #endif /* UNIT_TESTING_MODE */
-
+BatteryModule battery;
 /** Constructor - initializes the BatteryModule with default values,
  * sets up the CAN interface, and prepares the frame receiver. */
 BatteryModule::BatteryModule() : moduleId(0x11),
@@ -94,14 +94,17 @@ void BatteryModule::parseBatteryInfo(const std::string &data, float &energy, flo
         if (line.find("energy:") != std::string::npos)
         {
             energy = std::stof(line.substr(line.find(":") + 1));
+            ecu_data[0x01A0] = {static_cast<uint8_t>(energy)};
         }
         else if (line.find("voltage:") != std::string::npos)
         {
             voltage = std::stof(line.substr(line.find(":") + 1));
+            ecu_data[0x01B0] = {static_cast<uint8_t>(voltage)};
         }
         else if (line.find("percentage:") != std::string::npos)
         {
             percentage = std::stof(line.substr(line.find(":") + 1));
+            ecu_data[0x01C0] = {static_cast<uint8_t>(percentage)};
         }
         else if (line.find("state:") != std::string::npos)
         {
@@ -110,6 +113,34 @@ void BatteryModule::parseBatteryInfo(const std::string &data, float &energy, flo
             state = line.substr(pos + 1);
             /* Remove leading whitespace */
             state = state.substr(state.find_first_not_of(" \t"));
+            if(state == "unknown")
+            {
+                ecu_data[0x01D0] = {0x00};
+            }
+            else if(state == "charging")
+            {
+                ecu_data[0x01D0] = {0x01};
+            }
+            else if(state == "discharging")
+            {
+                ecu_data[0x01D0] = {0x02};
+            }
+            else if(state == "empty")
+            {
+                ecu_data[0x01D0] = {0x03};
+            }
+            else if(state == "fully-charged")
+            {
+                ecu_data[0x01D0] = {0x04};
+            }
+            else if(state == "pending-charge")
+            {
+                ecu_data[0x01D0] = {0x05};
+            }
+            else if(state == "pending-discharge")
+            {
+                ecu_data[0x01D0] = {0x06};
+            }
         }
     }
 }

--- a/src/ecu_simulation/BatteryModule/src/HandleFrames.cpp
+++ b/src/ecu_simulation/BatteryModule/src/HandleFrames.cpp
@@ -281,7 +281,8 @@ void HandleFrames::handleCompleteData(int id,const std::vector<uint8_t>& stored_
                     /* Combine the two bytes into a single 16-bit identifier */ 
                     uint16_t identifier = (stored_data[2] << 8) | stored_data[3];
                     LOG_INFO(batteryModuleLogger.GET_LOGGER(), "Stored data: {}", static_cast<int>(identifier));
-                    /* readDataByIdentifierRequest(id, identifier); */
+                    ReadDataByIdentifier read_data_by_identifier;
+                    read_data_by_identifier.readDataByIdentifier(id, stored_data, batteryModuleLogger);
                 }
                 break;
             }

--- a/src/mcu/Makefile
+++ b/src/mcu/Makefile
@@ -5,7 +5,8 @@ CFLAGSTST2 = -lgtest -lgtest_main -lpthread
 LDFLAGS = -lspdlog
 CFLAGSTST += -DUNIT_TESTING_MODE
 #Sources files
-SRCS = src/main.cpp src/MCUModule.cpp ../utils/src/GenerateFrames.cpp src/HandleFrames.cpp ../utils/src/CreateInterface.cpp src/ReceiveFrames.cpp
+SRCS = src/main.cpp src/MCUModule.cpp ../ecu_simulation/BatteryModule/src/BatteryModule.cpp ../utils/src/GenerateFrames.cpp src/HandleFrames.cpp ../utils/src/CreateInterface.cpp src/ReceiveFrames.cpp ../uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp  ../ecu_simulation/BatteryModule/src/HandleFrames.cpp  ../ecu_simulation/BatteryModule/src/ReceiveFrames.cpp 
+SRCSTEST = src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp  ../uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp ../ecu_simulation/BatteryModule/src/HandleFrames.cpp ../ecu_simulation/BatteryModule/src/ReceiveFrames.cpp ../ecu_simulation/BatteryModule/src/BatteryModule.cpp
 #Object files
 OBJS = $(patsubst ../utils/src/%.cpp src/%.cpp, obj/%.o, $(SRCS))
 OBJS:= $(OBJS) obj/Logger.o
@@ -21,7 +22,7 @@ $(FINAL): $(OBJS)
 	$(CXX) $(CFLAGS) -o $(FINAL) $(OBJS) ${LDFLAGS}
 $(OBJ_DIR):
 	mkdir -p $(OBJ_DIR)
-$(OBJ_DIR)/main.o: src/main.cpp include/MCUModule.h include/ReceiveFrames.h include/HandleFrames.h ../utils/include/GenerateFrames.h ../utils/include/Logger.h ../utils/include/CreateInterface.h include/MCULogger.h
+$(OBJ_DIR)/main.o: src/main.cpp include/MCUModule.h include/ReceiveFrames.h include/HandleFrames.h ../utils/include/GenerateFrames.h ../utils/include/Logger.h ../utils/include/CreateInterface.h include/MCULogger.h ../uds/read_data_by_identifier/include/ReadDataByIdentifier.h ../ecu_simulation/BatteryModule/include/BatteryModule.h   ../ecu_simulation/BatteryModule/include/HandleFrames.h  ../ecu_simulation/BatteryModule/include/ReceiveFrames.h
 	$(CXX) $(CFLAGS) -c src/main.cpp -o $(OBJ_DIR)/main.o
 $(OBJ_DIR)/MCUModule.o: src/MCUModule.cpp
 	$(CXX) $(CFLAGS) -c src/MCUModule.cpp -o $(OBJ_DIR)/MCUModule.o
@@ -50,27 +51,27 @@ allTests: handleTest receiveTest generateTest createInterfaceTest
 # HandleFrames Unit tests
 handleTest: HandleFrames_test
 HandleFrames_test: test/HandleFrames_test.cpp src/HandleFrames.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -o test/HandleFrames_test test/HandleFrames_test.cpp src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -o test/HandleFrames_test test/HandleFrames_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 
 # ReceiveFrames Unit tests
 receiveTest: ReceiveFrames_test
 ReceiveFrames_test: test/ReceiveFramesTest.cpp src/ReceiveFrames.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -o test/ReceiveFramesTest test/ReceiveFramesTest.cpp src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -o test/ReceiveFramesTest test/ReceiveFramesTest.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 
 # GenerateFrames Unit tests
 generateTest: GenerateFrames_test
 GenerateFrames_test: ../utils/test/GenerateFramesTest.cpp ../utils/src/GenerateFrames.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -o test/GenerateFramesTest ../utils/test/GenerateFramesTest.cpp src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -o ../utils/test/GenerateFramesTest ../utils/test/GenerateFramesTest.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 
 # CreateInterface Unit tests
 createInterfaceTest: CreateInterface_test
 CreateInterface_test: ../utils/test/CreateInterface_test.cpp ../utils/src/CreateInterface.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 
 # HandleFrames Coverage
 handleCoverage: HandleFramesCoverage
 HandleFramesCoverage: test/HandleFrames_test.cpp src/HandleFrames.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/HandleFrames_test test/HandleFrames_test.cpp src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/HandleFrames_test test/HandleFrames_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./test/HandleFrames_test
 	mkdir -p coverage/out_HandleFrames
 	gcov -o . src/HandleFrames.cpp
@@ -80,14 +81,12 @@ HandleFramesCoverage: test/HandleFrames_test.cpp src/HandleFrames.cpp
 	lcov --remove coverage.info '/test/' --output-file coverage.info
 	genhtml coverage_filtered.info --output-directory coverage/out_HandleFrames
 	xdg-open coverage/out_HandleFrames/index.html
-	find . -name '.gcno' -delete
-	find . -name '.gcda' -delete
-	find . -name '.gcov' -delete
+
 
 # ReceiveFrames Coverage
 receiveCoverage: ReceiveFramesCoverage
 ReceiveFramesCoverage: test/ReceiveFramesTest.cpp src/ReceiveFrames.cpp
-	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/ReceiveFramesTest test/ReceiveFramesTest.cpp src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/ReceiveFramesTest test/ReceiveFramesTest.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./test/ReceiveFramesTest
 	mkdir -p coverage/out_ReceiveFrames
 	gcov -o . src/ReceiveFrames.cpp
@@ -104,8 +103,8 @@ ReceiveFramesCoverage: test/ReceiveFramesTest.cpp src/ReceiveFrames.cpp
 # generateFrames Coverage
 generateCoverage: GenerateFramesCoverage
 GenerateFramesCoverage: ../utils/test/GenerateFramesTest.cpp ../utils/src/GenerateFrames.cpp
-	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/GenerateFramesTest ../utils/test/GenerateFramesTest.cpp src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
-	./test/GenerateFrames_Test
+	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/GenerateFramesTest ../utils/test/GenerateFramesTest.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
+	./../utils/test/GenerateFramesTest
 	mkdir -p coverage/out_GenerateFrames
 	gcov -o . ../utils/src/GenerateFrames.cpp
 	mv GenerateFrames.cpp.gcov coverage/out_GenerateFrames
@@ -121,7 +120,7 @@ GenerateFramesCoverage: ../utils/test/GenerateFramesTest.cpp ../utils/src/Genera
 # CreateInterface Coverage
 createInterfaceCoverage: CreateInterfaceCoverage
 CreateInterfaceCoverage: ../utils/test/CreateInterface_test.cpp ../utils/src/CreateInterface.cpp
-	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./../utils/test/CreateInterface_test
 	mkdir -p coverage/out_CreateInterface
 	gcov -o . ../utils/src/CreateInterface.cpp
@@ -138,28 +137,28 @@ CreateInterfaceCoverage: ../utils/test/CreateInterface_test.cpp ../utils/src/Cre
 allCoverage: HandleFrames_coverage ReceiveFrames_coverage GenerateFrames_coverage CreateInterface_coverage
 
 HandleFrames_coverage:
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/HandleFrames_test test/HandleFrames_test.cpp src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/HandleFrames_test test/HandleFrames_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./test/HandleFrames_test
 	mkdir -p coverage/out_HandleFrames
 	gcov -o . src/HandleFrames.cpp
 	mv HandleFrames.cpp.gcov coverage/out_HandleFrames
 
 ReceiveFrames_coverage:
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/ReceiveFramesTest test/ReceiveFramesTest.cpp src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/ReceiveFramesTest test/ReceiveFramesTest.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./test/ReceiveFramesTest
 	mkdir -p coverage/out_ReceiveFrames
 	gcov -o . src/ReceiveFrames.cpp
 	mv ReceiveFrames.cpp.gcov coverage/out_ReceiveFrames
 
 GenerateFrames_coverage:
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/GenerateFrames_Test test/GenerateFrames_Test.cpp src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o test/GenerateFrames_Test test/GenerateFrames_Test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./test/GenerateFrames_Test
 	mkdir -p coverage/out_GenerateFrames
 	gcov -o . ../utils/src/GenerateFrames.cpp
 	mv GenerateFrames.cpp.gcov coverage/out_GenerateFrames
 
 CreateInterface_coverage:
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
 	./../utils/test/CreateInterface_test
 	mkdir -p coverage/out_CreateInterface
 	gcov -o . ../utils/src/CreateInterface.cpp

--- a/src/mcu/include/HandleFrames.h
+++ b/src/mcu/include/HandleFrames.h
@@ -18,36 +18,38 @@
 #include <iostream>
 #include <vector>
 #include "../include/MCULogger.h"
-
-class HandleFrames 
+#include "../../uds/read_data_by_identifier/include/ReadDataByIdentifier.h"
+namespace MCU
 {
-public:
-    /**
-     * @brief Method used to handle a can frame received from the ReceiveFrame class.
-     * Takes a can_frame as parameter, checks if the frame is complete and then calls
-     * processFrameData() with either a single or multi frame.
-     * @param[in] frame The received frame.
-    */
-    void handleFrame(const struct can_frame &frame);
-    /**
-     * @brief Method used to call a service or handle a response.
-     * It takes frame_id, service id(sid) and frame_data and calls the right service or
-     * handles the response received based on the given parameters.
-     * @param[in] frame_id The frame ID used for the handling.
-     * @param[in] sid The service identifier.
-     * @param[in] frame_data The data held by the frame.
-     * @param[in] is_multi_frame Flag that checks if the frame is a multiframe.
-    */
-    void processFrameData(canid_t frame_id, uint8_t sid, std::vector<uint8_t> frame_data, bool is_multi_frame);
-    /**
-     * @brief Method used to send a frame based on the nrc(negative response code) received.
-     * It takes as parameters frame_id, sid to identify the service, and nrc to send the correct
-     * negative response code back to who made the request.
-     * @param[in] frame_id The frame ID used for the handling.
-     * @param[in] sid The service identifier.
-     * @param[in] nrc The negative response code.
-     */
-    void processNrc(canid_t frame_id, uint8_t sid, uint8_t nrc);
-};
-
-#endif // HANDLE_FRAMES_H
+    class HandleFrames 
+    {
+    public:
+        /**
+         * @brief Method used to handle a can frame received from the ReceiveFrame class.
+         * Takes a can_frame as parameter, checks if the frame is complete and then calls
+         * processFrameData() with either a single or multi frame.
+         * @param[in] frame The received frame.
+        */
+        void handleFrame(const struct can_frame &frame);
+        /**
+         * @brief Method used to call a service or handle a response.
+         * It takes frame_id, service id(sid) and frame_data and calls the right service or
+         * handles the response received based on the given parameters.
+         * @param[in] frame_id The frame ID used for the handling.
+         * @param[in] sid The service identifier.
+         * @param[in] frame_data The data held by the frame.
+         * @param[in] is_multi_frame Flag that checks if the frame is a multiframe.
+        */
+        void processFrameData(canid_t frame_id, uint8_t sid, std::vector<uint8_t> frame_data, bool is_multi_frame);
+        /**
+         * @brief Method used to send a frame based on the nrc(negative response code) received.
+         * It takes as parameters frame_id, sid to identify the service, and nrc to send the correct
+         * negative response code back to who made the request.
+         * @param[in] frame_id The frame ID used for the handling.
+         * @param[in] sid The service identifier.
+         * @param[in] nrc The negative response code.
+         */
+        void processNrc(canid_t frame_id, uint8_t sid, uint8_t nrc);
+    };
+}
+#endif /* HANDLE_FRAMES_H */

--- a/src/mcu/include/MCUModule.h
+++ b/src/mcu/include/MCUModule.h
@@ -13,48 +13,52 @@
 #include "../include/MCULogger.h"
 
 #include <thread>
+namespace MCU
+{
+    class MCUModule {
+    public:
+        /* Variable to store mcu data */
+        std::unordered_map<uint16_t, std::vector<uint8_t>> mcu_data;
+        /** 
+         * @brief Constructor that takes the interface number as an argument.
+         * When the constructor is called, it creates a new interface with the
+         * given number and starts the interface.
+         * @param interface_number The number of the vcan interface
+        */
+        MCUModule(uint8_t interfaces_number);
+        
+        /**
+         * @brief Default constructor for MCU Module.
+         */
+        MCUModule();
 
-class MCUModule {
-public:
-    /** 
-     * @brief Constructor that takes the interface number as an argument.
-     * When the constructor is called, it creates a new interface with the
-     * given number and starts the interface.
-     * @param interface_number The number of the vcan interface
-    */
-    MCUModule(uint8_t interfaces_number);
-    
-    /**
-     * @brief Default constructor for MCU Module.
-     */
-    MCUModule();
+        /**
+         * @brief Destructor for MCU Module.
+         */
+        ~MCUModule();
 
-    /**
-     * @brief Destructor for MCU Module.
-     */
-    ~MCUModule();
+        /**
+         * @brief Method to start the module. Sets isRunning flag to true.
+        */
+        void StartModule();
 
-    /**
-     * @brief Method to start the module. Sets isRunning flag to true.
-    */
-    void StartModule();
+        /**
+         * @brief Method to stop the module. Sets isRunning flag to false.
+        */
+        void StopModule();
 
-    /**
-     * @brief Method to stop the module. Sets isRunning flag to false.
-    */
-    void StopModule();
+        /**
+         * @brief Method to receive frames.
+         * This method starts a thread to process the queue and receives frames
+         * from the CAN bus.
+        */
+        void recvFrames();
 
-    /**
-     * @brief Method to receive frames.
-     * This method starts a thread to process the queue and receives frames
-     * from the CAN bus.
-    */
-    void recvFrames();
-
-private:
-    bool is_running;
-    CreateInterface* create_interface;
-    ReceiveFrames* receive_frames;
-};
-
-#endif 
+    private:
+        bool is_running;
+        CreateInterface* create_interface;
+        ReceiveFrames* receive_frames;
+    };
+extern MCUModule mcu;
+}
+#endif

--- a/src/mcu/include/ReceiveFrames.h
+++ b/src/mcu/include/ReceiveFrames.h
@@ -54,138 +54,139 @@
 #include "HandleFrames.h"
 #include "../../utils/include/GenerateFrames.h"
 #include "../include/MCULogger.h"
-
-class ReceiveFrames
+namespace MCU
 {
- public:
-
-  /**
-   * @brief Parameterized constructor.
-   * @param socket_canbus Socket for ECU communication.
-   * @param socket_api Socket for API communication.
-   */
-  ReceiveFrames(int socket_canbus, int socket_api);
-
-  /**
-   * @brief Destructor.
-   */
-  ~ReceiveFrames();
-
-  /**
-   * @brief Function that take the frame from CANBus and put it in process queue.
-   * @return Returns 1 for error and 0 for successfully.
-   */
-  bool receiveFramesFromCANBus();
-
-   /**
-   * @brief Function that take the frame from API and put it in process queue.
-   * @return Returns 1 for error and 0 for successfully.
-   */
-  bool receiveFramesFromAPI();
-
-
-  /**
-   * @brief Function that take each frame from process queue and partially parse the frame to know
-    for who is the frame. After, call handle class.
-   */
-  void processQueue();
-
-  /**
-   * @brief Function that print a frame with all information. 
-   * @param frame The frame that will be printed.
-   */
-  void printFrames(const struct can_frame &frame);
-
-  /**
-   * @brief Function to send test frame on CANBus.
-   * 
-   */
-  void sendTestFrame();
-
-  /**
-   * @brief Set listenAPI member to false.
-   */
-  void stopListenAPI();
+  class ReceiveFrames
+  {
+  public:
 
     /**
-   * @brief Set listenCANBus member to false.
-   */
-  void stopListenCANBus();
+     * @brief Parameterized constructor.
+     * @param socket_canbus Socket for ECU communication.
+     * @param socket_api Socket for API communication.
+     */
+    ReceiveFrames(int socket_canbus, int socket_api);
 
-  /**
-   * @brief Set listenAPI member to true.
-   */
-  void startListenAPI();
+    /**
+     * @brief Destructor.
+     */
+    ~ReceiveFrames();
 
-  /**
-   * @brief Set listenCANBus member to true.
-   */
-  void startListenCANBus();
+    /**
+     * @brief Function that take the frame from CANBus and put it in process queue.
+     * @return Returns 1 for error and 0 for successfully.
+     */
+    bool receiveFramesFromCANBus();
 
-  /**
-   * @brief Get method for hexValueId.
-   * @return Returns hexValueId for the object. 
-   */
-  uint32_t gethexValueId();
+    /**
+     * @brief Function that take the frame from API and put it in process queue.
+     * @return Returns 1 for error and 0 for successfully.
+     */
+    bool receiveFramesFromAPI();
 
-  /**
-   * @brief Get method for listen_api flag.
-   * @return Returns the listen_api flag. 
-   */
-  bool getListenAPI();
 
-  /**
-   * @brief Get method for listen_canbus flag.
-   * @return Returns the listen_canbus flag. 
-   */
-  bool getListenCANBus();
+    /**
+     * @brief Function that take each frame from process queue and partially parse the frame to know
+      for who is the frame. After, call handle class.
+    */
+    void processQueue();
 
-  /**
-   * @brief Get method for the list of ECUs that are up.
-   * @return Returns ecus_up (the list of ECUs that are up). 
-   */
-  const uint8_t* getECUsUp() const;
+    /**
+     * @brief Function that print a frame with all information. 
+     * @param frame The frame that will be printed.
+     */
+    void printFrames(const struct can_frame &frame);
 
-  std::map<uint8_t, std::chrono::steady_clock::time_point> ecu_timers;
-  std::chrono::seconds timeout_duration;
-  std::thread timer_thread;
-  bool running;
-  
- protected:
-  /* The socket from where we read the frames */
-  int socket_canbus;
-  int socket_api;
-  const uint32_t hex_value_id = 0x10;
-  std::queue<struct can_frame> frame_queue;
-  std::mutex queue_mutex;
-  std::condition_variable queue_cond_var;
-  bool listen_api;
-  bool listen_canbus;
-  HandleFrames handler;
-  GenerateFrames generate_frames;
-  /* Vector contains all the ECUs up ids */
-  uint8_t ecus_up[4] = {0};
+    /**
+     * @brief Function to send test frame on CANBus.
+     * 
+     */
+    void sendTestFrame();
 
-  /**
-   * @brief Starts timer_thread and sets running flag on true.
-   */
-  void startTimerThread();
+    /**
+     * @brief Set listenAPI member to false.
+     */
+    void stopListenAPI();
 
-  /**
-   * @brief Stops timer_thread and sets running flag on false.
-   */
-  void stopTimerThread();
+      /**
+     * @brief Set listenCANBus member to false.
+     */
+    void stopListenCANBus();
 
-  /**
-   * @brief Checks timer and send requests to check if the ECUs are up.
-   */
-  void timerCheck();
+    /**
+     * @brief Set listenAPI member to true.
+     */
+    void startListenAPI();
 
-  /**
-   * @brief Reset the timer and add the ECU to the list.
-   * @param ecu_id The identifier of the ECU (will be added to the list).
-   */
-  void resetTimer(uint8_t ecu_id);
-};
+    /**
+     * @brief Set listenCANBus member to true.
+     */
+    void startListenCANBus();
 
+    /**
+     * @brief Get method for hexValueId.
+     * @return Returns hexValueId for the object. 
+     */
+    uint32_t gethexValueId();
+
+    /**
+     * @brief Get method for listen_api flag.
+     * @return Returns the listen_api flag. 
+     */
+    bool getListenAPI();
+
+    /**
+     * @brief Get method for listen_canbus flag.
+     * @return Returns the listen_canbus flag. 
+     */
+    bool getListenCANBus();
+
+    /**
+     * @brief Get method for the list of ECUs that are up.
+     * @return Returns ecus_up (the list of ECUs that are up). 
+     */
+    const uint8_t* getECUsUp() const;
+
+    std::map<uint8_t, std::chrono::steady_clock::time_point> ecu_timers;
+    std::chrono::seconds timeout_duration;
+    std::thread timer_thread;
+    bool running;
+    
+  protected:
+    /* The socket from where we read the frames */
+    int socket_canbus;
+    int socket_api;
+    const uint32_t hex_value_id = 0x10;
+    std::queue<struct can_frame> frame_queue;
+    std::mutex queue_mutex;
+    std::condition_variable queue_cond_var;
+    bool listen_api;
+    bool listen_canbus;
+    HandleFrames handler;
+    GenerateFrames generate_frames;
+    /* Vector contains all the ECUs up ids */
+    uint8_t ecus_up[4] = {0};
+
+    /**
+     * @brief Starts timer_thread and sets running flag on true.
+     */
+    void startTimerThread();
+
+    /**
+     * @brief Stops timer_thread and sets running flag on false.
+     */
+    void stopTimerThread();
+
+    /**
+     * @brief Checks timer and send requests to check if the ECUs are up.
+     */
+    void timerCheck();
+
+    /**
+     * @brief Reset the timer and add the ECU to the list.
+     * @param ecu_id The identifier of the ECU (will be added to the list).
+     */
+    void resetTimer(uint8_t ecu_id);
+  };
+}
 #endif /* POC_SRC_MCU_RECEIVE_FRAME_MODULE_H */

--- a/src/mcu/src/HandleFrames.cpp
+++ b/src/mcu/src/HandleFrames.cpp
@@ -6,448 +6,452 @@
  * 
  */
 #include "../include/HandleFrames.h"
-
-/* Method to handle a can frame */
-void HandleFrames::handleFrame(const struct can_frame &frame) 
+namespace MCU
 {
-    /* Indicates whether the first frame has been received */
-    static bool first_frame_received = false;
-    /* Number of expected bytes of payload for multi-frame sequence */
-    static uint8_t expected_payload = 0;
-    /* frame data - for both single and multi frame sequence */
-    static std::vector<uint8_t> frame_data;
-    /* remember SID in case of multi-frame sequence*/
-    static uint8_t sid = 0;
-    /* check if the data is split across multiple frames */
-    static bool is_multi_frame = false;
-    /* Expected sequence number for consecutive frames */
-    static uint8_t expected_sequence_number = 0x21;
-
-    /* frame integrity checks will remain in Receive class for now */
-    /* id < 0x10 == single frame*/
-    if (frame.data[0] < 0x10) 
+    /* Method to handle a can frame */
+    void HandleFrames::handleFrame(const struct can_frame &frame) 
     {
-        /* if frame is negative response, 0x7F takes sid's place so sid comes next to it */
-        if (frame.data[1] == 0x7F)
-        {
-            sid = frame.data[2];
-        }
-        else
-        {
-            sid = frame.data[1];  
-        }
-        LOG_INFO(MCULogger.GET_LOGGER(), "Single Frame received:");
-        for (uint8_t data_pos = 0; data_pos < frame.can_dlc; ++data_pos) 
-        {
-            frame_data.push_back(frame.data[data_pos]);
-        }
-        std::cout << std::endl;
-        is_multi_frame = false;
-        /* Enter the switch case */
-        processFrameData(frame.can_id, sid, frame_data, is_multi_frame);
-        /* clear data to be used by a future frame */
-        frame_data.clear();
-    /* id == 0x10 == first frame */
-    } 
-    else if (frame.data[0] == 0x10) 
-    {   
-        /* Number of expected bytes of payload */
-        expected_payload = frame.data[1];
-        /* Number of expected frames */
-        uint8_t expected_frames = frame.data[1] / 7;
-        if(frame.data[1] % 7 > 0)
-        {
-            expected_frames++;
-        }
-        /* get SID from the first frame */
-        sid = frame.data[2];
-        LOG_INFO(MCULogger.GET_LOGGER(), "Multi-frame Sequence with {} {}", (int)expected_frames, "frames");
+        /* Indicates whether the first frame has been received */
+        static bool first_frame_received = false;
+        /* Number of expected bytes of payload for multi-frame sequence */
+        static uint8_t expected_payload = 0;
+        /* frame data - for both single and multi frame sequence */
+        static std::vector<uint8_t> frame_data;
+        /* remember SID in case of multi-frame sequence*/
+        static uint8_t sid = 0;
+        /* check if the data is split across multiple frames */
+        static bool is_multi_frame = false;
+        /* Expected sequence number for consecutive frames */
+        static uint8_t expected_sequence_number = 0x21;
 
-        /* Clear the multi_frame_data vector when receiving the first frame */
-        frame_data.clear();
-
-        /* Concatenate the data from the first frame into multi_frame_data */
-        for (uint8_t data_pos = 5; data_pos < frame.can_dlc; ++data_pos) 
+        /* frame integrity checks will remain in Receive class for now */
+        /* id < 0x10 == single frame*/
+        if (frame.data[0] < 0x10) 
         {
-            frame_data.push_back(frame.data[data_pos]);
-        }
-        /* Make sure sequenceNumber is set after receiving the first frame */
-        expected_sequence_number = 0x21;
-        first_frame_received = true;
-    /* id >= 0x20 == consecutive frame */
-    } 
-    else if (frame.data[0] >= 0x21 && frame.data[0] < 0x30) 
-    {
-        if (!first_frame_received) 
-        {
-            /* Ignore consecutive frames until the first frame is received */
-            return;
-        }
-        /* Check if the frame's sequence number matches the expected sequence number */
-        if (frame.data[0] != expected_sequence_number) 
-        {
-            LOG_ERROR(MCULogger.GET_LOGGER(), "Invalid consecutive frame sequence: expected {} {} {}", int(expected_sequence_number), "but received", int(frame.data[0]));
-            return;
-        }
-        /* Concatenate the data from consecutive frames into multi_frame_data */
-        for (uint8_t data_pos = 1; data_pos < frame.can_dlc; ++data_pos) 
-        {
-            frame_data.push_back(frame.data[data_pos]);
-        }
-        /* Increment sequenceNumber after each concatenation*/
-        expected_sequence_number++;
-         /* Check if all multi-frames have been received */
-        if (frame_data.size() >= expected_payload) 
-        { 
-            LOG_INFO(MCULogger.GET_LOGGER(), "Data is: ");
-            for (uint8_t data_pos = 0; data_pos < (int)frame_data.size(); ++data_pos) 
+            /* if frame is negative response, 0x7F takes sid's place so sid comes next to it */
+            if (frame.data[1] == 0x7F)
             {
-                LOG_INFO(MCULogger.GET_LOGGER(), int(frame_data[data_pos]));
+                sid = frame.data[2];
+            }
+            else
+            {
+                sid = frame.data[1];  
+            }
+            LOG_INFO(MCULogger.GET_LOGGER(), "Single Frame received:");
+            for (uint8_t data_pos = 0; data_pos < frame.can_dlc; ++data_pos) 
+            {
+                frame_data.push_back(frame.data[data_pos]);
             }
             std::cout << std::endl;
-            is_multi_frame = true;
+            is_multi_frame = false;
             /* Enter the switch case */
             processFrameData(frame.can_id, sid, frame_data, is_multi_frame);
-            /* Reset sequenceNumber for the next sequence */
-            expected_sequence_number = 0x21;
-            /* Reset variables */
-            first_frame_received = false;
-            expected_payload = 0;
+            /* clear data to be used by a future frame */
             frame_data.clear();
+        /* id == 0x10 == first frame */
+        } 
+        else if (frame.data[0] == 0x10) 
+        {   
+            /* Number of expected bytes of payload */
+            expected_payload = frame.data[1];
+            /* Number of expected frames */
+            uint8_t expected_frames = frame.data[1] / 7;
+            if(frame.data[1] % 7 > 0)
+            {
+                expected_frames++;
+            }
+            /* get SID from the first frame */
+            sid = frame.data[2];
+            LOG_INFO(MCULogger.GET_LOGGER(), "Multi-frame Sequence with {} {}", (int)expected_frames, "frames");
+
+            /* Clear the multi_frame_data vector when receiving the first frame */
+            frame_data.clear();
+
+            /* Concatenate the data from the first frame into multi_frame_data */
+            for (uint8_t data_pos = 5; data_pos < frame.can_dlc; ++data_pos) 
+            {
+                frame_data.push_back(frame.data[data_pos]);
+            }
+            /* Make sure sequenceNumber is set after receiving the first frame */
+            expected_sequence_number = 0x21;
+            first_frame_received = true;
+        /* id >= 0x20 == consecutive frame */
+        } 
+        else if (frame.data[0] >= 0x21 && frame.data[0] < 0x30) 
+        {
+            if (!first_frame_received) 
+            {
+                /* Ignore consecutive frames until the first frame is received */
+                return;
+            }
+            /* Check if the frame's sequence number matches the expected sequence number */
+            if (frame.data[0] != expected_sequence_number) 
+            {
+                LOG_ERROR(MCULogger.GET_LOGGER(), "Invalid consecutive frame sequence: expected {} {} {}", int(expected_sequence_number), "but received", int(frame.data[0]));
+                return;
+            }
+            /* Concatenate the data from consecutive frames into multi_frame_data */
+            for (uint8_t data_pos = 1; data_pos < frame.can_dlc; ++data_pos) 
+            {
+                frame_data.push_back(frame.data[data_pos]);
+            }
+            /* Increment sequenceNumber after each concatenation*/
+            expected_sequence_number++;
+            /* Check if all multi-frames have been received */
+            if (frame_data.size() >= expected_payload) 
+            { 
+                LOG_INFO(MCULogger.GET_LOGGER(), "Data is: ");
+                for (uint8_t data_pos = 0; data_pos < (int)frame_data.size(); ++data_pos) 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), int(frame_data[data_pos]));
+                }
+                std::cout << std::endl;
+                is_multi_frame = true;
+                /* Enter the switch case */
+                processFrameData(frame.can_id, sid, frame_data, is_multi_frame);
+                /* Reset sequenceNumber for the next sequence */
+                expected_sequence_number = 0x21;
+                /* Reset variables */
+                first_frame_received = false;
+                expected_payload = 0;
+                frame_data.clear();
+            }
+        } 
+        else 
+        {
+            LOG_ERROR(MCULogger.GET_LOGGER(), "Invalid frame type.");
         }
-    } 
-    else 
-    {
-        LOG_ERROR(MCULogger.GET_LOGGER(), "Invalid frame type.");
     }
-}
 
-/* Method to call the service or handle the response*/
-void HandleFrames::processFrameData(canid_t frame_id, uint8_t sid, std::vector<uint8_t> frame_data, bool is_multi_frame) 
-{
-
-    switch (sid) {
-        case 0x10:
-            /* DiagnosticSessionControl(sid, frame_data[2]); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {    
-                LOG_INFO(MCULogger.GET_LOGGER(), "DiagnosticSessionControl called.");
-            }
-            break;
-        case 0x11:
-            /* EcuReset(sid, frame_data[2]); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "EcuReset called.");
-            }
-            break;
-        case 0x27:
-            /* SecurityAccess(sid, frame_data[2], key?); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "SecurityAccess called.");
-            }
-            break;
-        case 0x29:
-            /* Authentication(); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "Authentication called.");
-            }
-            break;
-        case 0x3E:
-            /* TesterPresent(sid, frame_data[2]); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "TesterPresent called.");
-            }
-            break;
-        case 0x83:
-            /* AccessTimingParameters(sid, frame_data[2]); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "AccessTimingParameters called.");
-            }
-            break;
-        case 0x22:
-            /* ReadDataByIdentifier(sid, frame_data[2] << 8) | frame_data[3]); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "ReadDataByIdentifier called.");
-            }
-            break;
-        case 0x23:
-            /* ReadMemoryByAddress(frame_data[2], frame_data[3] << 8) | frame_data[4], frame_data[5] << 8) | frame_data[6]); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "ReadMemoryByAddress called.");
-            }
-            break;
-        case 0x2E:
-            /* WriteDataByIdentifier(sid, frame_data[2] << 8) | frame_data[3], data_parameter?); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else if (is_multi_frame)
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "WriteDataByIdentifier called with multiple frames.");
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "WriteDataByIdentifier called with one frame.");
-            }
-            break;
-        case 0x14:
-            /* ClearDiagnosticInformation(); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "ClearDiagnosticInformation called.");
-            }
-            break;
-        case 0x19:
-            /* ReadDtcInformation(); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "ReadDtcInformation called.");
-            }
-            break;
-        case 0x31:
-            /* RoutineControl(sid, frame_data[2], frame_data[3] << 8) | frame_data[4]); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "RoutineControl called.");
-            }
-            break;
-        /* UDS Responses */
-        case 0x50:
-            /* Response for DiagnosticSessionControl */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response for DiagnosticSessionControl received.");
-            break;
-        case 0x51:
-            /* Response from EcuReset() service */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response from EcuReset received.");
-            break;
-        case 0x67:
-            /* Response from SecurityAccess() service */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response from SecurityAccess received.");
-            break;
-        case 0x69:
-            /* Response from Authentication() service */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response from Authentication received.");
-            break;
-        case 0x7E:
-            /* Response from TesterPresent() service */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response from TesterPresent received.");
-            break;
-        case 0xC3:
-            /* Response from AccessTimingParameters() service */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response from AccessTimingParameters received.");
-            break;
-        case 0x62:
-            /* Response from ReadDataByIdentifier() service */
-            if(is_multi_frame)
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(),"Response from ReadDataByIdentifier received.");
-                LOG_INFO(MCULogger.GET_LOGGER(), "Received multiple frames containing {} {}", frame_data.size(), "bytes of data");
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(),"Response from ReadDataByIdentifier received in one frame.");
-            }
-            break;
-        case 0x63:
-            /* Response from ReadMemoryByAddress() service */
-            if(is_multi_frame)
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(),"Response from ReadMemoryByAdress received.");
-                LOG_INFO(MCULogger.GET_LOGGER(),"Received multiple frames containing {} {}", frame_data.size(), "bytes of data");
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(),"Response from ReadMemoryByAdress received in one frame.");
-            }
-            break;
-        case 0x6E:
-            /* Response from WriteDataByIdentifier() service */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response from WriteDataByIdentifier received.");
-            break;
-        case 0x54:
-            /* Response from ClearDiagnosticInformation() service */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response from ClearDiagnosticInformation received.");
-            break;
-        case 0x59:
-            /* Response from ReadDtcInformation() service */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response from ReadDtcInformation received.");
-            break;
-        case 0x71:
-            /* Response from RoutineControl() service */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response from RoutineControl received.");
-            break;
-        /* OTA Requests */
-        case 0x34:
-            /* RequestDownload(sid, frame_data[2], frame_data[3], frame_data[4], frame_data[5]); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "RequestDownload called.");
-            }
-            break;
-        case 0x36:
-            /* TransferData(sid, frame_data[2], frame_data[3], frame_data[4]); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else if(is_multi_frame)
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "TransferData called with multiple frames.");
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "TransferData called with one frame.");
-            }
-            break;
-        case 0x37:
-            /* RequestTransferExit(sid, frame_data[2]); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "RequestTransferExit called.");
-            }
-            break;
-        case 0x32:
-            /* RequestUpdateStatus(); */
-            if(frame_data[1] == 0x7F)
-            {
-                processNrc(frame_id, sid, frame_data[3]);
-            }
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(), "RequestUpdateStatus called.");
-            }
-            break;
-        /* OTA Responses */
-        case 0x74:
-            /* Response from RequestDownload() service */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response from RequestDownload received.");
-            break;
-        case 0x76:
-            /* Response from TransferData() service */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response from TransferData received.");
-            break;
-        case 0x77:
-            /* Response from RequestTransferExit() service */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response from RequestTransferExit received.");
-            break;
-        case 0x72:
-            /* Response from RequestUpdateStatus() service */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Response from RequestUpdateStatus received.");
-            break;
-        default:
-            /* Unknown request/response */
-            LOG_INFO(MCULogger.GET_LOGGER(), "Unknown request/response received.");
-            break;
-    }
-}
-void HandleFrames::processNrc(canid_t frame_id, uint8_t sid, uint8_t nrc)
-{
-    switch(nrc)
+    /* Method to call the service or handle the response*/
+    void HandleFrames::processFrameData(canid_t frame_id, uint8_t sid, std::vector<uint8_t> frame_data, bool is_multi_frame) 
     {
-        case 0x11:
-            /* Service not supported */
-            /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
-            LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Service not supported for service: {0:x}", (int)sid);
-            break;
-        case 0x13:
-            /* Incorrect message length or invalid format */
-            /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
-            LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Incorrect message length or invalid format for service: {0:x}", (int)sid);
-            break;
-        case 0x14:
-            /*  Response too long */
-            /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
-            LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Response too long for service: {0:x}", (int)sid);
-            break;
-        case 0x25:
-            /* No response from subnet component */
-            /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
-            LOG_ERROR(MCULogger.GET_LOGGER(), "Error: No response from subnet component for service: {0:x}", (int)sid);
-            break;
-        case 0x34:
-            /* Authentication failed */
-            /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
-            LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Authentication failed for service: {0:x}", (int)sid);
-            break;
-        case 0x94:
-            /* Resource temporarily unavailable */
-            /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
-            LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Resource temporarily unavailable for service: {0:x}", (int)sid);
-            break;
-        case 0x70:
-            /* Upload download not accepted */
-            /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
-            LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Upload download not accepted for service: {0:x}", (int)sid);
-            break;
-        case 0x71:
-            /* Transfer data suspended */
-            /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
-            LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Transfer data suspended for service: {0:x}", (int)sid);
-            break;
-        default:
-            /* Unknown negative response code */
-            /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
-            LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Unknown negative response code for service: {0:x}", (int)sid);
-            break;
+
+        switch (sid) {
+            case 0x10:
+                /* DiagnosticSessionControl(sid, frame_data[2]); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {    
+                    LOG_INFO(MCULogger.GET_LOGGER(), "DiagnosticSessionControl called.");
+                }
+                break;
+            case 0x11:
+                /* EcuReset(sid, frame_data[2]); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "EcuReset called.");
+                }
+                break;
+            case 0x27:
+                /* SecurityAccess(sid, frame_data[2], key?); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "SecurityAccess called.");
+                }
+                break;
+            case 0x29:
+                /* Authentication(); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "Authentication called.");
+                }
+                break;
+            case 0x3E:
+                /* TesterPresent(sid, frame_data[2]); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "TesterPresent called.");
+                }
+                break;
+            case 0x83:
+                /* AccessTimingParameters(sid, frame_data[2]); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "AccessTimingParameters called.");
+                }
+                break;
+            case 0x22:
+                /* ReadDataByIdentifier(sid, frame_data[2] << 8) | frame_data[3]); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "ReadDataByIdentifier called.");
+                    ReadDataByIdentifier read_data_by_identifier;
+                    read_data_by_identifier.readDataByIdentifier(frame_id, frame_data, MCULogger);
+                }
+                break;
+            case 0x23:
+                /* ReadMemoryByAddress(frame_data[2], frame_data[3] << 8) | frame_data[4], frame_data[5] << 8) | frame_data[6]); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "ReadMemoryByAddress called.");
+                }
+                break;
+            case 0x2E:
+                /* WriteDataByIdentifier(sid, frame_data[2] << 8) | frame_data[3], data_parameter?); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else if (is_multi_frame)
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "WriteDataByIdentifier called with multiple frames.");
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "WriteDataByIdentifier called with one frame.");
+                }
+                break;
+            case 0x14:
+                /* ClearDiagnosticInformation(); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "ClearDiagnosticInformation called.");
+                }
+                break;
+            case 0x19:
+                /* ReadDtcInformation(); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "ReadDtcInformation called.");
+                }
+                break;
+            case 0x31:
+                /* RoutineControl(sid, frame_data[2], frame_data[3] << 8) | frame_data[4]); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "RoutineControl called.");
+                }
+                break;
+            /* UDS Responses */
+            case 0x50:
+                /* Response for DiagnosticSessionControl */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response for DiagnosticSessionControl received.");
+                break;
+            case 0x51:
+                /* Response from EcuReset() service */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response from EcuReset received.");
+                break;
+            case 0x67:
+                /* Response from SecurityAccess() service */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response from SecurityAccess received.");
+                break;
+            case 0x69:
+                /* Response from Authentication() service */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response from Authentication received.");
+                break;
+            case 0x7E:
+                /* Response from TesterPresent() service */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response from TesterPresent received.");
+                break;
+            case 0xC3:
+                /* Response from AccessTimingParameters() service */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response from AccessTimingParameters received.");
+                break;
+            case 0x62:
+                /* Response from ReadDataByIdentifier() service */
+                if(is_multi_frame)
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(),"Response from ReadDataByIdentifier received.");
+                    LOG_INFO(MCULogger.GET_LOGGER(), "Received multiple frames containing {} {}", frame_data.size(), "bytes of data");
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(),"Response from ReadDataByIdentifier received in one frame.");
+                }
+                break;
+            case 0x63:
+                /* Response from ReadMemoryByAddress() service */
+                if(is_multi_frame)
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(),"Response from ReadMemoryByAdress received.");
+                    LOG_INFO(MCULogger.GET_LOGGER(),"Received multiple frames containing {} {}", frame_data.size(), "bytes of data");
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(),"Response from ReadMemoryByAdress received in one frame.");
+                }
+                break;
+            case 0x6E:
+                /* Response from WriteDataByIdentifier() service */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response from WriteDataByIdentifier received.");
+                break;
+            case 0x54:
+                /* Response from ClearDiagnosticInformation() service */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response from ClearDiagnosticInformation received.");
+                break;
+            case 0x59:
+                /* Response from ReadDtcInformation() service */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response from ReadDtcInformation received.");
+                break;
+            case 0x71:
+                /* Response from RoutineControl() service */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response from RoutineControl received.");
+                break;
+            /* OTA Requests */
+            case 0x34:
+                /* RequestDownload(sid, frame_data[2], frame_data[3], frame_data[4], frame_data[5]); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "RequestDownload called.");
+                }
+                break;
+            case 0x36:
+                /* TransferData(sid, frame_data[2], frame_data[3], frame_data[4]); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else if(is_multi_frame)
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "TransferData called with multiple frames.");
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "TransferData called with one frame.");
+                }
+                break;
+            case 0x37:
+                /* RequestTransferExit(sid, frame_data[2]); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "RequestTransferExit called.");
+                }
+                break;
+            case 0x32:
+                /* RequestUpdateStatus(); */
+                if(frame_data[1] == 0x7F)
+                {
+                    processNrc(frame_id, sid, frame_data[3]);
+                }
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(), "RequestUpdateStatus called.");
+                }
+                break;
+            /* OTA Responses */
+            case 0x74:
+                /* Response from RequestDownload() service */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response from RequestDownload received.");
+                break;
+            case 0x76:
+                /* Response from TransferData() service */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response from TransferData received.");
+                break;
+            case 0x77:
+                /* Response from RequestTransferExit() service */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response from RequestTransferExit received.");
+                break;
+            case 0x72:
+                /* Response from RequestUpdateStatus() service */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Response from RequestUpdateStatus received.");
+                break;
+            default:
+                /* Unknown request/response */
+                LOG_INFO(MCULogger.GET_LOGGER(), "Unknown request/response received.");
+                break;
+        }
+    }
+    void HandleFrames::processNrc(canid_t frame_id, uint8_t sid, uint8_t nrc)
+    {
+        switch(nrc)
+        {
+            case 0x11:
+                /* Service not supported */
+                /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
+                LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Service not supported for service: {0:x}", (int)sid);
+                break;
+            case 0x13:
+                /* Incorrect message length or invalid format */
+                /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
+                LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Incorrect message length or invalid format for service: {0:x}", (int)sid);
+                break;
+            case 0x14:
+                /*  Response too long */
+                /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
+                LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Response too long for service: {0:x}", (int)sid);
+                break;
+            case 0x25:
+                /* No response from subnet component */
+                /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
+                LOG_ERROR(MCULogger.GET_LOGGER(), "Error: No response from subnet component for service: {0:x}", (int)sid);
+                break;
+            case 0x34:
+                /* Authentication failed */
+                /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
+                LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Authentication failed for service: {0:x}", (int)sid);
+                break;
+            case 0x94:
+                /* Resource temporarily unavailable */
+                /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
+                LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Resource temporarily unavailable for service: {0:x}", (int)sid);
+                break;
+            case 0x70:
+                /* Upload download not accepted */
+                /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
+                LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Upload download not accepted for service: {0:x}", (int)sid);
+                break;
+            case 0x71:
+                /* Transfer data suspended */
+                /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
+                LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Transfer data suspended for service: {0:x}", (int)sid);
+                break;
+            default:
+                /* Unknown negative response code */
+                /* GenerateFrames::negativeResponse(can_id, sid, nrc); */
+                LOG_ERROR(MCULogger.GET_LOGGER(), "Error: Unknown negative response code for service: {0:x}", (int)sid);
+                break;
+        }
     }
 }

--- a/src/mcu/src/MCUModule.cpp
+++ b/src/mcu/src/MCUModule.cpp
@@ -5,56 +5,59 @@ Logger MCULogger("MCULogger", "logs/MCULogs.log");
 #else
 Logger MCULogger;
 #endif /* UNIT_TESTING_MODE */
-
-/* Constructor */
-MCUModule::MCUModule(uint8_t interfaces_number) : 
-                create_interface(CreateInterface::getInstance(interfaces_number, MCULogger)),
-                is_running(false),
-                receive_frames(nullptr) 
-                {
-    receive_frames = new ReceiveFrames(create_interface->getSocketEcuRead(), create_interface->getSocketApiRead());
-
-}
-
-/* Default constructor */
-MCUModule::MCUModule() : create_interface(CreateInterface::getInstance(0x01, MCULogger)),
-                                            is_running(false),
-                                            receive_frames(nullptr) {}
-
-/* Destructor */
-MCUModule::~MCUModule() 
+namespace MCU
 {
-    create_interface->stopInterface();
-    delete receive_frames;
-}
+    MCUModule mcu(0x01);
+    /* Constructor */
+    MCUModule::MCUModule(uint8_t interfaces_number) : 
+                    create_interface(CreateInterface::getInstance(interfaces_number, MCULogger)),
+                    is_running(false),
+                    receive_frames(nullptr) 
+                    {
+        receive_frames = new ReceiveFrames(create_interface->getSocketEcuRead(), create_interface->getSocketApiRead());
 
-/* Start the module */
-void MCUModule::StartModule() { is_running = true; }
+    }
 
-/* Stop the module */
-void MCUModule::StopModule() { is_running = false; }
+    /* Default constructor */
+    MCUModule::MCUModule() : create_interface(CreateInterface::getInstance(0x01, MCULogger)),
+                                                is_running(false),
+                                                receive_frames(nullptr) {}
 
-/* Receive frames */
-void MCUModule::recvFrames() 
-{
-    while (is_running)
+    /* Destructor */
+    MCUModule::~MCUModule() 
     {
-        receive_frames->startListenAPI();
-        receive_frames->startListenCANBus();
-        /* Start a thread to process the queue */
-        std::thread queue_thread_process(&ReceiveFrames::processQueue, receive_frames);
+        create_interface->stopInterface();
+        delete receive_frames;
+    }
 
-        /* Start a thread to listen on API socket */
-        std::thread queue_thread_listen(&ReceiveFrames::receiveFramesFromAPI, receive_frames);
+    /* Start the module */
+    void MCUModule::StartModule() { is_running = true; }
 
-        /* Receive frames from the CAN bus */
-        receive_frames->receiveFramesFromCANBus();
+    /* Stop the module */
+    void MCUModule::StopModule() { is_running = false; }
 
-        receive_frames->stopListenAPI();
-        receive_frames->stopListenCANBus();
+    /* Receive frames */
+    void MCUModule::recvFrames() 
+    {
+        while (is_running)
+        {
+            receive_frames->startListenAPI();
+            receive_frames->startListenCANBus();
+            /* Start a thread to process the queue */
+            std::thread queue_thread_process(&ReceiveFrames::processQueue, receive_frames);
 
-        /* Wait for the threads to finish */
-        queue_thread_process.join();
-        queue_thread_listen.join();
+            /* Start a thread to listen on API socket */
+            std::thread queue_thread_listen(&ReceiveFrames::receiveFramesFromAPI, receive_frames);
+
+            /* Receive frames from the CAN bus */
+            receive_frames->receiveFramesFromCANBus();
+
+            receive_frames->stopListenAPI();
+            receive_frames->stopListenCANBus();
+
+            /* Wait for the threads to finish */
+            queue_thread_process.join();
+            queue_thread_listen.join();
+        }
     }
 }

--- a/src/mcu/src/ReceiveFrames.cpp
+++ b/src/mcu/src/ReceiveFrames.cpp
@@ -1,300 +1,301 @@
 #include "../include/ReceiveFrames.h"
-
-ReceiveFrames::ReceiveFrames(int socket_canbus, int socket_api)
-    : socket_canbus(socket_canbus), socket_api(socket_api), generate_frames(socket_canbus, MCULogger),
-      timeout_duration(120), running(true) 
+namespace MCU
 {
-    startTimerThread();
-}
-
-ReceiveFrames::~ReceiveFrames() 
-{
-    stopListenAPI();
-    stopListenCANBus();
-    stopTimerThread();
-}
-
-uint32_t ReceiveFrames::gethexValueId()
-{
-    return hex_value_id;
-}
-
-/**
- * Function to read frames from the CAN bus and add them to a queue.
- * This function runs in a loop and continually reads frames from the CAN bus.
- */
-bool ReceiveFrames::receiveFramesFromCANBus()
-{
-    struct can_frame frame;
-    while(listen_canbus)
+    ReceiveFrames::ReceiveFrames(int socket_canbus, int socket_api)
+        : socket_canbus(socket_canbus), socket_api(socket_api), generate_frames(socket_canbus, MCULogger),
+        timeout_duration(120), running(true) 
     {
-        /* Read frames from the CAN socket */
-        int nbytes = read(socket_canbus, &frame, sizeof(frame));
-        if (nbytes < 0)
-        {
-            LOG_ERROR(MCULogger.GET_LOGGER(),"Read Error");
-            /* Return error if read fails */
-            return false;
-        }
-        else
-        {
-            {
-                /* Lock the queue before adding the frame to ensure thread safety */
-                std::lock_guard<std::mutex> lock(queue_mutex);
-                /* Take receiver_id */
-                uint8_t dest_id = frame.can_id & 0xFF;
-
-                /* If frame is for MCU module, for API or test frame */
-                if( dest_id == hex_value_id || dest_id == 0xFF || dest_id == 0xFA)
-                {
-                    frame_queue.push(frame);
-                }
-            }
-            /* Notify one waiting thread that a new frame has been added to the queue */
-            queue_cond_var.notify_one();
-        }
+        startTimerThread();
     }
-    return true;
-}
 
-bool ReceiveFrames::receiveFramesFromAPI()
-{
-    struct can_frame frame;
-    while(listen_api)
+    ReceiveFrames::~ReceiveFrames() 
     {
-        /* Read frames from the CAN socket */
-        int nbytes = read(socket_api, &frame, sizeof(frame));
-        if (nbytes < 0)
-        {
-            LOG_ERROR(MCULogger.GET_LOGGER(),"Read Error");
-            /* Return error if read fails */
-            return false;
-        }
-        else
-        {
-            {
-                /* Lock the queue before adding the frame to ensure thread safety */
-                std::lock_guard<std::mutex> lock(queue_mutex);
-                frame_queue.push(frame);
-                
-            }
-            /* Notify one waiting thread that a new frame has been added to the queue */
-            queue_cond_var.notify_one();
-        }
+        stopListenAPI();
+        stopListenCANBus();
+        stopTimerThread();
     }
-    return true;
-}
 
-/*
- * Function to process frames from the queue.
- * This function runs in a loop and processes each frame from the queue.
- */
-void ReceiveFrames::processQueue() 
-{
-    LOG_INFO(MCULogger.GET_LOGGER(),"Frame processing:...");
-    while (true)
+    uint32_t ReceiveFrames::gethexValueId()
     {
-        /* Wait until the queue is not empty, then lock the queue */
-        std::unique_lock<std::mutex> lock(queue_mutex);
-        queue_cond_var.wait(lock, [this]{ return !frame_queue.empty(); });
+        return hex_value_id;
+    }
 
-        /* Extract the first element from the queue */
-        struct can_frame frame = frame_queue.front();
-        frame_queue.pop();
-        /* Unlock the queue to allow other threads to add frames */
-        lock.unlock();
-
-        /* Print the received CAN frame details */
-        printFrames(frame);
-
-        /* Extracting the components from can_id */
-
-        /* Last byte: id_sender */
-        uint8_t sender_id = (frame.can_id >> 8) & 0xFF;
-        /* First byte: id_receiver or id_api */
-        uint8_t dest_id = frame.can_id & 0xFF;
-
-        /* Compare the CAN ID with the expected hexValueId */
-        if (dest_id == hex_value_id) 
+    /**
+     * Function to read frames from the CAN bus and add them to a queue.
+     * This function runs in a loop and continually reads frames from the CAN bus.
+     */
+    bool ReceiveFrames::receiveFramesFromCANBus()
+    {
+        struct can_frame frame;
+        while(listen_canbus)
         {
-            if (frame.data[1] == 0xff) 
+            /* Read frames from the CAN socket */
+            int nbytes = read(socket_canbus, &frame, sizeof(frame));
+            if (nbytes < 0)
             {
-                LOG_INFO(MCULogger.GET_LOGGER(),"Notification from the ECU that it is up");
-                /* Set the corresponding value from the array with the ECU id */
-                switch(sender_id)
-                {
-                    case 0x11:
-                        ecus_up[0] = sender_id;
-                        break;
-                    case 0x12:
-                        ecus_up[1] = sender_id;
-                        break;
-                    case 0x13:
-                        ecus_up[2] = sender_id;
-                        break;
-                    case 0x14:
-                        ecus_up[3] = sender_id;
-                        break;
-                    default:
-                        break;
-                }
-
-                resetTimer(sender_id);
-            } 
-            else 
-            {
-                LOG_INFO(MCULogger.GET_LOGGER(),"Frame for MCU Service");
-                handler.handleFrame(frame);
-            }
-        }
-        else if (dest_id == 0xFA) {
-            LOG_INFO(MCULogger.GET_LOGGER(),"Frame for API Service");
-            std::vector<uint8_t> data(frame.data, frame.data + frame.can_dlc);
-        } 
-        else if (dest_id == 0xFF) 
-        {
-            /* Test frame between MCU and ECU */
-            LOG_INFO(MCULogger.GET_LOGGER(),"Received the test frame ");
-        }
-
-        if (sender_id == 0xFA && dest_id != hex_value_id) 
-        {
-            if(frame.data[1] == 0x99)
-            {
-                /** sends back to api a response with all ECUs IDs that are up 
-                    response structure: 
-                    id: MCU_id + API_id 
-                    data: {PCI_L, SID(0xD9), MCU_id, BATTERY_id, DOORS_id, ENGINE_id, ECU4_id}
-                */
-               LOG_INFO(MCULogger.GET_LOGGER(),"Response with all ECUs up.");
-                generate_frames.sendFrame(0x10FA,{0x07, 0xD9, (uint8_t)hex_value_id, ecus_up[0], ecus_up[1], ecus_up[2], ecus_up[3]}, socket_api, DATA_FRAME);
+                LOG_ERROR(MCULogger.GET_LOGGER(),"Read Error");
+                /* Return error if read fails */
+                return false;
             }
             else
             {
-                std::vector<uint8_t> data(frame.data, frame.data + frame.can_dlc);
-                LOG_INFO(MCULogger.GET_LOGGER(),"Frame for ECU Service");
-                generate_frames.sendFrame(frame.can_id, data);
+                {
+                    /* Lock the queue before adding the frame to ensure thread safety */
+                    std::lock_guard<std::mutex> lock(queue_mutex);
+                    /* Take receiver_id */
+                    uint8_t dest_id = frame.can_id & 0xFF;
+
+                    /* If frame is for MCU module, for API or test frame */
+                    if( dest_id == hex_value_id || dest_id == 0xFF || dest_id == 0xFA)
+                    {
+                        frame_queue.push(frame);
+                    }
+                }
+                /* Notify one waiting thread that a new frame has been added to the queue */
+                queue_cond_var.notify_one();
             }
         }
+        return true;
+    }
 
-        if (!listen_api && !listen_canbus) 
+    bool ReceiveFrames::receiveFramesFromAPI()
+    {
+        struct can_frame frame;
+        while(listen_api)
         {
-            break;
+            /* Read frames from the CAN socket */
+            int nbytes = read(socket_api, &frame, sizeof(frame));
+            if (nbytes < 0)
+            {
+                LOG_ERROR(MCULogger.GET_LOGGER(),"Read Error");
+                /* Return error if read fails */
+                return false;
+            }
+            else
+            {
+                {
+                    /* Lock the queue before adding the frame to ensure thread safety */
+                    std::lock_guard<std::mutex> lock(queue_mutex);
+                    frame_queue.push(frame);
+                    
+                }
+                /* Notify one waiting thread that a new frame has been added to the queue */
+                queue_cond_var.notify_one();
+            }
         }
+        return true;
     }
-}
 
-void ReceiveFrames::resetTimer(uint8_t ecu_id) {
-    std::lock_guard<std::mutex> lock(queue_mutex);
-    ecu_timers[ecu_id] = std::chrono::steady_clock::now();
-}
-
-/**
- * Function to print the frames.
- */
-void ReceiveFrames::printFrames(const struct can_frame &frame)
-{
-    std::ostringstream oss;
-    LOG_INFO(MCULogger.GET_LOGGER(),"-------------------\n");
-    LOG_INFO(MCULogger.GET_LOGGER(),"Processing CAN frame from queue:");
-    LOG_INFO(MCULogger.GET_LOGGER(), fmt::format("CAN ID: 0x{:x}", frame.can_id));
-    LOG_INFO(MCULogger.GET_LOGGER(), fmt::format("Data Length: {}", int(frame.can_dlc)));
-    oss << "Data: ";
-    for (uint8_t itr = 0; itr < frame.can_dlc; ++itr)
+    /*
+    * Function to process frames from the queue.
+    * This function runs in a loop and processes each frame from the queue.
+    */
+    void ReceiveFrames::processQueue() 
     {
-        oss << fmt::format("{} ", int(frame.data[itr]));
-    }
-    LOG_INFO(MCULogger.GET_LOGGER(), oss.str());
-}
+        LOG_INFO(MCULogger.GET_LOGGER(),"Frame processing:...");
+        while (true)
+        {
+            /* Wait until the queue is not empty, then lock the queue */
+            std::unique_lock<std::mutex> lock(queue_mutex);
+            queue_cond_var.wait(lock, [this]{ return !frame_queue.empty(); });
 
-/*
- * Function to send test frame 
-*/
-void ReceiveFrames::sendTestFrame()
-{
-    if(listen_canbus)
-    {
-        /* Set the CAN ID to 0xFF */
-        int can_id = 0xFF;
-        /* Set the data to an empty vector*/
-        std::vector<uint8_t> data;
-        /* Call Generate_frames and SendFrame with the test frame */
-        generate_frames.sendFrame(can_id, data);
-    }
-}
+            /* Extract the first element from the queue */
+            struct can_frame frame = frame_queue.front();
+            frame_queue.pop();
+            /* Unlock the queue to allow other threads to add frames */
+            lock.unlock();
 
-void ReceiveFrames::stopListenAPI()
-{
-    listen_api = false;
-    queue_cond_var.notify_all();
-}
+            /* Print the received CAN frame details */
+            printFrames(frame);
 
-void ReceiveFrames::stopListenCANBus()
-{
-    listen_canbus = false;
-    queue_cond_var.notify_all();
-}
+            /* Extracting the components from can_id */
 
-void ReceiveFrames::startListenAPI()
-{
-    listen_api = true;
-    queue_cond_var.notify_all();
-}
+            /* Last byte: id_sender */
+            uint8_t sender_id = (frame.can_id >> 8) & 0xFF;
+            /* First byte: id_receiver or id_api */
+            uint8_t dest_id = frame.can_id & 0xFF;
+            /* Compare the CAN ID with the expected hexValueId */
+            if (dest_id == hex_value_id) 
+            {
+                if (frame.data[1] == 0xff) 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(),"Notification from the ECU that it is up");
+                    /* Set the corresponding value from the array with the ECU id */
+                    switch(sender_id)
+                    {
+                        case 0x11:
+                            ecus_up[0] = sender_id;
+                            break;
+                        case 0x12:
+                            ecus_up[1] = sender_id;
+                            break;
+                        case 0x13:
+                            ecus_up[2] = sender_id;
+                            break;
+                        case 0x14:
+                            ecus_up[3] = sender_id;
+                            break;
+                        default:
+                            break;
+                    }
 
-void ReceiveFrames::startListenCANBus()
-{
-    listen_canbus = true;
-    queue_cond_var.notify_all();
-}
-
-bool ReceiveFrames::getListenAPI()
-{
-    return listen_api;
-}
-
-bool ReceiveFrames::getListenCANBus()
-{
-    return listen_canbus;
-}
-
-const uint8_t* ReceiveFrames::getECUsUp() const {
-    return ecus_up;
-}
-
-void ReceiveFrames::startTimerThread() {
-    running = true;
-    timer_thread = std::thread(&ReceiveFrames::timerCheck, this);
-}
-
-void ReceiveFrames::stopTimerThread() {
-    running = false;
-    if (timer_thread.joinable()) {
-        timer_thread.join();
-    }
-}
-
-void ReceiveFrames::timerCheck()
-{
-    try {
-        while (running) {
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-            auto now = std::chrono::steady_clock::now();
-            std::lock_guard<std::mutex> lock(queue_mutex);
-            for (auto it = ecu_timers.begin(); it != ecu_timers.end();) {
-                if (std::chrono::duration_cast<std::chrono::seconds>(now - it->second) >= timeout_duration) {
-                    uint8_t ecu_id = it->first;
-                    /* Send request frame */
-                    std::vector<uint8_t> data = {0x01};
-                    generate_frames.sendFrame(0x1011, data);
-                    it = ecu_timers.erase(it);
-                } else {
-                    ++it;
+                    resetTimer(sender_id);
+                } 
+                else 
+                {
+                    LOG_INFO(MCULogger.GET_LOGGER(),"Frame for MCU Service");
+                    handler.handleFrame(frame);
                 }
             }
+            else if (dest_id == 0xFA) {
+                LOG_INFO(MCULogger.GET_LOGGER(),"Frame for API Service");
+                std::vector<uint8_t> data(frame.data, frame.data + frame.can_dlc);
+            } 
+            else if (dest_id == 0xFF) 
+            {
+                /* Test frame between MCU and ECU */
+                LOG_INFO(MCULogger.GET_LOGGER(),"Received the test frame ");
+            }
+
+            if (sender_id == 0xFA && dest_id != hex_value_id) 
+            {
+                if(frame.data[1] == 0x99)
+                {
+                    /** sends back to api a response with all ECUs IDs that are up 
+                        response structure: 
+                        id: MCU_id + API_id 
+                        data: {PCI_L, SID(0xD9), MCU_id, BATTERY_id, DOORS_id, ENGINE_id, ECU4_id}
+                    */
+                LOG_INFO(MCULogger.GET_LOGGER(),"Response with all ECUs up.");
+                    generate_frames.sendFrame(0x10FA,{0x07, 0xD9, (uint8_t)hex_value_id, ecus_up[0], ecus_up[1], ecus_up[2], ecus_up[3]}, socket_api, DATA_FRAME);
+                }
+                else
+                {
+                    std::vector<uint8_t> data(frame.data, frame.data + frame.can_dlc);
+                    LOG_INFO(MCULogger.GET_LOGGER(),"Frame for ECU Service");
+                    generate_frames.sendFrame(frame.can_id, data);
+                }
+            }
+
+            if (!listen_api && !listen_canbus) 
+            {
+                break;
+            }
         }
-    } catch (const std::exception& e) {
-        std::cerr << "Exception in timerCheck: " << e.what() << std::endl;
-    } catch (...) {
-        std::cerr << "Unknown exception in timerCheck" << std::endl;
+    }
+
+    void ReceiveFrames::resetTimer(uint8_t ecu_id) {
+        std::lock_guard<std::mutex> lock(queue_mutex);
+        ecu_timers[ecu_id] = std::chrono::steady_clock::now();
+    }
+
+    /**
+     * Function to print the frames.
+     */
+    void ReceiveFrames::printFrames(const struct can_frame &frame)
+    {
+        std::ostringstream oss;
+        LOG_INFO(MCULogger.GET_LOGGER(),"-------------------\n");
+        LOG_INFO(MCULogger.GET_LOGGER(),"Processing CAN frame from queue:");
+        LOG_INFO(MCULogger.GET_LOGGER(), fmt::format("CAN ID: 0x{:x}", frame.can_id));
+        LOG_INFO(MCULogger.GET_LOGGER(), fmt::format("Data Length: {}", int(frame.can_dlc)));
+        oss << "Data: ";
+        for (uint8_t itr = 0; itr < frame.can_dlc; ++itr)
+        {
+            oss << fmt::format("0x{:x} ", frame.data[itr]);
+        }
+        LOG_INFO(MCULogger.GET_LOGGER(), oss.str());
+    }
+
+    /*
+    * Function to send test frame 
+    */
+    void ReceiveFrames::sendTestFrame()
+    {
+        if(listen_canbus)
+        {
+            /* Set the CAN ID to 0xFF */
+            int can_id = 0xFF;
+            /* Set the data to an empty vector*/
+            std::vector<uint8_t> data;
+            /* Call Generate_frames and SendFrame with the test frame */
+            ReceiveFrames::generate_frames.sendFrame(can_id, data);
+        }
+    }
+
+    void ReceiveFrames::stopListenAPI()
+    {
+        listen_api = false;
+        queue_cond_var.notify_all();
+    }
+
+    void ReceiveFrames::stopListenCANBus()
+    {
+        listen_canbus = false;
+        queue_cond_var.notify_all();
+    }
+
+    void ReceiveFrames::startListenAPI()
+    {
+        ReceiveFrames::listen_api = true;
+        queue_cond_var.notify_all();
+    }
+
+    void ReceiveFrames::startListenCANBus()
+    {
+        listen_canbus = true;
+        queue_cond_var.notify_all();
+    }
+
+    bool ReceiveFrames::getListenAPI()
+    {
+        return listen_api;
+    }
+
+    bool ReceiveFrames::getListenCANBus()
+    {
+        return listen_canbus;
+    }
+
+    const uint8_t* ReceiveFrames::getECUsUp() const {
+        return ecus_up;
+    }
+
+    void ReceiveFrames::startTimerThread() {
+        running = true;
+        timer_thread = std::thread(&ReceiveFrames::timerCheck, this);
+    }
+
+    void ReceiveFrames::stopTimerThread() {
+        running = false;
+        if (timer_thread.joinable()) {
+            timer_thread.join();
+        }
+    }
+
+    void ReceiveFrames::timerCheck()
+    {
+        try {
+            while (running) {
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+                auto now = std::chrono::steady_clock::now();
+                std::lock_guard<std::mutex> lock(queue_mutex);
+                for (auto it = ecu_timers.begin(); it != ecu_timers.end();) {
+                    if (std::chrono::duration_cast<std::chrono::seconds>(now - it->second) >= timeout_duration) {
+                        uint8_t ecu_id = it->first;
+                        /* Send request frame */
+                        std::vector<uint8_t> data = {0x01};
+                        ReceiveFrames::generate_frames.sendFrame(0x1011, data);
+                        it = ecu_timers.erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "Exception in timerCheck: " << e.what() << std::endl;
+        } catch (...) {
+            std::cerr << "Unknown exception in timerCheck" << std::endl;
+        }
     }
 }

--- a/src/mcu/src/main.cpp
+++ b/src/mcu/src/main.cpp
@@ -1,8 +1,7 @@
 #include "../include/MCUModule.h"
 
 int main() {
-    MCUModule mcuModule(0x01);
-    mcuModule.StartModule();
-    mcuModule.recvFrames();
+    MCU::mcu.StartModule();
+    MCU::mcu.recvFrames();
     return 0;
 }

--- a/src/mcu/test/HandleFrames_test.cpp
+++ b/src/mcu/test/HandleFrames_test.cpp
@@ -6,7 +6,7 @@ class HandleFramesTest : public ::testing::Test{
     public:
     HandleFramesTest(){}
     protected:
-    HandleFrames handler;
+    MCU::HandleFrames handler;
     struct can_frame testFrame;
 };
 
@@ -26,7 +26,6 @@ TEST_F(HandleFramesTest, DiagnosticSessionControlValTest){
     /* simulated frame_data for valid single frame response */
     std::vector<uint8_t> frame_data = {0x03, 0x10};
     bool isMultiFrame = false;
-
     /* redirect stdout to capture the output */
     testing::internal::CaptureStdout();
     handler.processFrameData(testFrame.can_id, sid, frame_data, isMultiFrame);

--- a/src/mcu/test/ReceiveFramesTest.cpp
+++ b/src/mcu/test/ReceiveFramesTest.cpp
@@ -13,7 +13,7 @@
 #include <atomic>
 
 /* MockReceiveFrames class derived from ReceiveFrames to expose protected members for testing */
-class MockReceiveFrames : public ReceiveFrames
+class MockReceiveFrames : public MCU::ReceiveFrames
 {
 public:
     MockReceiveFrames(int socket_api, int socket_canbus) : ReceiveFrames(socket_api, socket_canbus) {}

--- a/src/uds/read_data_by_identifier/include/ReadDataByIdentifier.h
+++ b/src/uds/read_data_by_identifier/include/ReadDataByIdentifier.h
@@ -1,0 +1,46 @@
+/**
+ * @file ReadDataByIdentifier.h
+ * @author your name (you@domain.com)
+ * @brief This library represents the ReadDataByIdentifier UDS service.
+ * It retrieves data based on the Data Identifier(DID) received in the can_frame.]
+ * For example, if you want to know the battery voltage, 0x01B0 DID is responsible for that.
+ * The request frame receive by the service will have the format: frame.data = {PCI_L(1byte), SID(1byte = 0x22), DID(2bytes),Padding(4bytes)}
+ * The positive response frame sent by the service will have the format: frame.data = {PCI_L(1byte), RESPONSE_SID(1byte = 0x62), DID(2bytes), DATA}
+ * The negative response frame sent by the service will have the format: frame.data = {PCI_L(1byte), 0x7F, SID(1byte = 0x22), NRC(1byte)}
+ */
+
+
+#include <linux/can.h>
+#include <vector>
+#include <unordered_map>
+#include <bitset>
+
+#include "../../../utils/include/CreateInterface.h"
+#include "../../../utils/include/GenerateFrames.h"
+#include "../../utils/include/Logger.h"
+
+#ifndef UDS_READ_DATA_BY_IDENTIFIER_H
+#define UDS_READ_DATA_BY_IDENTIFIER_H
+
+class ReadDataByIdentifier
+{
+    public:
+    /**
+    * @brief Default constructor
+    */
+    ReadDataByIdentifier();
+    /**
+    * @brief Method that retrieves some data based on a DID.
+    * @param can_id The frame id.
+    * @param request Data from a can frame that contains PCI, SID and DID
+    * @param RDBILogger Logger reference to log in a specific file.
+    */
+    std::vector<uint8_t> readDataByIdentifier(canid_t can_id, const std::vector<uint8_t>& request, Logger& RDBILogger);
+    
+    private:
+    GenerateFrames* generate_frames;
+    CreateInterface* create_interface;
+
+};
+
+#endif

--- a/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
+++ b/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
@@ -1,0 +1,119 @@
+#include "../include/ReadDataByIdentifier.h"
+#include "../../../ecu_simulation/BatteryModule/include/BatteryModule.h"
+#include "../../../mcu/include/MCUModule.h"
+
+ReadDataByIdentifier::ReadDataByIdentifier()
+{}
+
+/* Define the service identifier for Read Data By Identifier */
+const uint8_t RDBI_SERVICE_ID = 0x22;
+
+/* Function to handle the Read Data By Identifier request */
+std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, const std::vector<uint8_t>& request, Logger& rdbi_logger) {
+    std::vector<uint8_t> response;
+    /* Extract the data identifier from the request */
+    uint16_t data_identifier = (request[2] << 8) | request[3];
+        
+    /**Extract the first 8 bits of can_id */
+    uint8_t lowerbits = can_id & 0xFF;
+    uint8_t upperbits = can_id >> 8 & 0xFF;
+
+    /* Vector to store data from ecuData */
+    std::vector<uint8_t> stored_data;
+
+    /* Reverse ids */
+    can_id = ((lowerbits << 8) | upperbits);
+    if (request.size() < 3) 
+    {
+        /** Invalid request length */
+        response.push_back(0x03); /* PCI */
+        response.push_back(0x7F); /** Negative response */
+        response.push_back(RDBI_SERVICE_ID);
+        response.push_back(0x13); /** Incorrect message length or invalid format */
+    }
+    else
+    {
+        /** Determine which ECU data storage to use based on the first 8 bits of can_id */
+        if (lowerbits == 0x10 && MCU::mcu.mcu_data.find(data_identifier) != MCU::mcu.mcu_data.end()) 
+        {
+            stored_data = MCU::mcu.mcu_data.at(data_identifier);
+            /* Positive response */
+            response.clear();
+            response.push_back(0x03); /* PCI */
+            response.push_back(0x62); /* Response sid = initial sid + 0x40 */
+            response.push_back(request[2]); /* Data identifier, two bytes */
+            response.push_back(request[3]);
+            /* Append the data corresponding to the identifier */
+            response.insert(response.end(), stored_data.begin(), stored_data.end());
+        } 
+        else if (lowerbits == 0x11 && battery.ecu_data.find(data_identifier) != battery.ecu_data.end()) 
+        {
+            /* fetch the data from linux */
+            battery.fetchBatteryData();
+            stored_data = battery.ecu_data.at(data_identifier);
+            /** Positive response */
+            response.clear();
+            response.push_back(0x03); /* PCI */
+            response.push_back(0x62); /* Response sid = initial sid + 0x40 */
+            response.push_back(request[2]); /* Data identifier, two bytes */
+            response.push_back(request[3]);
+            /** Append the data corresponding to the identifier */
+            response.insert(response.end(), stored_data.begin(), stored_data.end());
+        } 
+        else 
+        {
+            /** Data identifier not found */
+            /** response.push_back(0x03); */
+            /** response.push_back(0x7F); */ /** Negative response */
+            /** response.push_back(RDBI_SERVICE_ID); */
+            /** response.push_back(0x31); */ /** Request out of range */
+
+            /* 0x31 NRC is not yet defined so I log it instead */
+            LOG_ERROR(rdbi_logger.GET_LOGGER(), "Request out of range");
+        }
+    }
+    /* Check if sender was API so MCU will send directly to API */
+    if (upperbits == 0xFA) 
+    {
+        create_interface = create_interface->getInstance(0x00, rdbi_logger);
+        if (create_interface) 
+        {   
+            generate_frames = new GenerateFrames(create_interface->getSocketApiWrite(), rdbi_logger);
+            if(response.size() > 8)
+            {
+                generate_frames->readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
+            }
+            else
+            {
+                generate_frames->readDataByIdentifier(can_id, data_identifier, response);
+            }
+        } 
+        else 
+        {
+            /* Handle the case where create_interface is null */
+            LOG_ERROR(rdbi_logger.GET_LOGGER(), "create_interface is nullptr");
+        }
+    } 
+    else 
+    {
+        create_interface = create_interface->getInstance(0x00, rdbi_logger);
+        if (create_interface) 
+        {
+            generate_frames = new GenerateFrames(create_interface->getSocketEcuWrite(), rdbi_logger);
+            if(response.size() > 8)
+            {
+                generate_frames->readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
+            }
+            else
+            {
+                generate_frames->readDataByIdentifier(can_id, data_identifier, response);
+            }
+        } 
+        else 
+        {
+            /* Handle the case where create_interface is null */
+            LOG_ERROR(rdbi_logger.GET_LOGGER(), "create_interface is nullptr");
+        }
+    }
+    return response;
+}

--- a/src/utils/include/GenerateFrames.h
+++ b/src/utils/include/GenerateFrames.h
@@ -43,6 +43,7 @@ class GenerateFrames
          * 
          * @param socket 
          */
+        GenerateFrames();
         GenerateFrames(int socket, Logger& logger);
         int getSocket();
         /**

--- a/src/utils/src/GenerateFrames.cpp
+++ b/src/utils/src/GenerateFrames.cpp
@@ -1,5 +1,7 @@
 #include "../include/GenerateFrames.h"
-
+GenerateFrames::GenerateFrames()
+    : logger(logger)
+{}
 GenerateFrames::GenerateFrames(int socket, Logger& logger)
     : logger(logger), socket(socket)
 {
@@ -17,7 +19,7 @@ struct can_frame GenerateFrames::createFrame(int &id,  std::vector<uint8_t> &dat
     switch (frameType)
     {
         case DATA_FRAME:
-            frame.can_id = id & CAN_EFF_MASK;
+            frame.can_id = (id & CAN_EFF_MASK) | CAN_EFF_FLAG;
             frame.can_dlc = data.size();
             for (uint8_t byte = 0; byte < frame.can_dlc; byte++)
             {
@@ -25,7 +27,7 @@ struct can_frame GenerateFrames::createFrame(int &id,  std::vector<uint8_t> &dat
             }
             break;
         case REMOTE_FRAME:
-            frame.can_id = id & CAN_EFF_MASK;
+            frame.can_id = (id & CAN_EFF_MASK) | CAN_EFF_FLAG;
             frame.can_id |= CAN_RTR_FLAG;
             frame.can_dlc = data.size();
             for (uint8_t byte = 0; byte < frame.can_dlc; byte++)


### PR DESCRIPTION
- Added the service and used it in handleFrames
- Updated makefiles to compile Ecu files on MCU side and viceversa
- Added a default constructor on generateFrames because I forgot to add it in the previous PR
- Created a namespace on MCU side to avoid duplicate files on compile(two receiveFrames and two handleFrames)
- Made the module objects as externs to be able to access its data inside service.
- parseBatteryInfo now adds linux data into ecuData map according to DIDs document available on gspace.

Tested and works on both ECU and MCU side.
I will add more DIDs in the map when we decide which DIDs are needed.