### PR TITLE
One socket for each module

### DIFF
--- a/src/ecu_simulation/BatteryModule/Makefile
+++ b/src/ecu_simulation/BatteryModule/Makefile
@@ -1,10 +1,10 @@
 #Compiler flags
-CFLAGS = -g -Wall -pthread -I./include -I./src -I../../utils/include -I../../utils/src -I../../uds/include -I../../uds/src
+CFLAGS = -std=c++17 -g -Wall -pthread -I./include -I./src -I../../utils/include -I../../utils/src -I../../uds/include -I../../uds/src
 CFLAGSTST = -std=c++17 -I/include -DUNIT_TESTING_MODE
 LDFLAGS = -lspdlog
 CFLAGSTST2 = -lgtest -lgtest_main -pthread
 #Sources files
-SRCS = src/main.cpp src/BatteryModule.cpp ../../utils/src/GenerateFrames.cpp src/HandleFrames.cpp ../../utils/src/CreateInterface.cpp src/ReceiveFrames.cpp ../../uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp ../../uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp ../../uds/ecu_reset/src/EcuReset.cpp ../../mcu/src/HandleFrames.cpp ../../mcu/src/ReceiveFrames.cpp ../../mcu/src/MCUModule.cpp ../../uds/read_dtc_information/src/ReadDtcInformation.cpp
+SRCS = src/main.cpp src/BatteryModule.cpp ../../utils/src/GenerateFrames.cpp src/HandleFrames.cpp ../../utils/src/CreateInterface.cpp src/ReceiveFrames.cpp ../../uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp ../../uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp ../../uds/ecu_reset/src/EcuReset.cpp ../../mcu/src/HandleFrames.cpp ../../mcu/src/ReceiveFrames.cpp ../../mcu/src/MCUModule.cpp ../../uds/read_dtc_information/src/ReadDtcInformation.cpp ../../uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp ../../uds/authentication/src/SecurityAccess.cpp ../../ota/request_download/src/RequestDownload.cpp ../../ota/request_update_status/src/RequestUpdateStatus.cpp 
 SRCSTEST = src/HandleFrames.cpp src/BatteryModule.cpp src/ReceiveFrames.cpp ../../utils/src/GenerateFrames.cpp ../../utils/src/CreateInterface.cpp ../../uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp ../../utils/src/Logger.cpp ../../uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp ../../uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp ../../uds/ecu_reset/src/EcuReset.cpp ../../mcu/src/HandleFrames.cpp ../../mcu/src/ReceiveFrames.cpp ../../mcu/src/MCUModule.cpp ../../uds/read_dtc_information/src/ReadDtcInformation.cpp
 
 #Object files
@@ -75,7 +75,7 @@ GenerateFrames_test: ../../utils/test/GenerateFramesTest.cpp ../../utils/src/Gen
 # CreateInterface Unit tests
 createInterfaceTest: CreateInterface_test
 CreateInterface_test: ../../utils/test/CreateInterface_test.cpp ../../utils/src/CreateInterface.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -o ../../utils/test/CreateInterface_test ../../utils/test/CreateInterface_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -o ../../utils/test/CreateInterface_test ../../utils/test/CreateInterface_test.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
 
 # ReadDataByIdentifier Unit tests
 RDBITest: ReadDataByIdentifier_test
@@ -158,7 +158,7 @@ GenerateFramesCoverage: ../../utils/test/GenerateFramesTest.cpp ../../utils/src/
 # CreateInterface Coverage
 createInterfaceCoverage: CreateInterfaceCoverage
 CreateInterfaceCoverage: ../../utils/test/CreateInterface_test.cpp ../../utils/src/CreateInterface.cpp
-	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../../utils/test/CreateInterface_test ../../utils/test/CreateInterface_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
+	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../../utils/test/CreateInterface_test ../../utils/test/CreateInterface_test.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
 	./../../utils/test/CreateInterface_test
 	mkdir -p coverage/out_CreateInterface
 	gcov -o . ../../utils/src/CreateInterface.cpp
@@ -220,7 +220,7 @@ GenerateFrames_coverage:
 	mv GenerateFrames.cpp.gcov coverage/out_GenerateFrames
 
 CreateInterface_coverage:
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp ../../utils/src/CreateInterface.cpp ../../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
 	./../utils/test/CreateInterface_test
 	mkdir -p coverage/out_CreateInterface
 	gcov -o . ../../utils/src/CreateInterface.cpp

--- a/src/ecu_simulation/BatteryModule/include/BatteryModule.h
+++ b/src/ecu_simulation/BatteryModule/include/BatteryModule.h
@@ -32,6 +32,7 @@ class BatteryModule
 {
 private:
     int moduleId;
+    int battery_socket = -1;
 
     float energy;
     float voltage;
@@ -135,6 +136,7 @@ public:
      * @return Returns Battery State - charging, discharging, fully-charged, etc.
      */
     std::string getLinuxBatteryState();
+    int getBatterySocket() const;
 };
 extern BatteryModule battery;
 

--- a/src/ecu_simulation/BatteryModule/include/HandleFrames.h
+++ b/src/ecu_simulation/BatteryModule/include/HandleFrames.h
@@ -32,7 +32,7 @@
 #include "../../../uds/write_data_by_identifier/include/WriteDataByIdentifier.h"
 #include "../../../utils/include/CreateInterface.h"
 #include "../../../uds/ecu_reset/include/EcuReset.h"
-#include "../../uds/read_dtc_information/include/ReadDtcInformation.h"
+#include "../../../uds/read_dtc_information/include/ReadDtcInformation.h"
 
 class HandleFrames 
 {
@@ -58,11 +58,12 @@ private:
     bool first_frame = false;  
     /* Vector to store data subfunction */ 
     uint8_t sub_function;
+    /* socket */
+    int socket = -1;
 
     /**
      * @brief Diagnostic Control Session object instance
      * this will enable the Default Session at module start
-     * 
      */
     DiagnosticSessionControl diagnosticSessionControl;
                     
@@ -70,8 +71,11 @@ public:
     /**
      * @brief Default constructor for Handle Frames object.
      */
-    HandleFrames() : expected_data_size(0), flag(0), diagnosticSessionControl(moduleId, batteryModuleLogger) {}
-
+    HandleFrames();
+    /**
+     * @brief  constructor that takes a socket as parameter for Handle Frames object.
+     */
+    HandleFrames(int socket);
     /**
      * @brief Method for checking the validity of the received CAN frame.
      * 

--- a/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
+++ b/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
@@ -15,8 +15,9 @@ BatteryModule::BatteryModule() : moduleId(0x11),
                                  canInterface(CreateInterface::getInstance(0x00, batteryModuleLogger)),
                                  frameReceiver(nullptr)
 {
+    battery_socket = canInterface->createSocket(0x00);
     /* Initialize the Frame Receiver */
-    frameReceiver = new ReceiveFrames(canInterface->getSocketEcuRead(), moduleId);
+    frameReceiver = new ReceiveFrames(battery_socket, moduleId);
 
     LOG_INFO(batteryModuleLogger.GET_LOGGER(), "Battery object created successfully, ID : 0x{:X}", this->moduleId);
 
@@ -32,12 +33,13 @@ BatteryModule::BatteryModule(int _interfaceNumber, int _moduleId) : moduleId(_mo
                                                                     canInterface(CreateInterface::getInstance(_interfaceNumber, batteryModuleLogger)),
                                                                     frameReceiver(nullptr)
 {
+    battery_socket = canInterface->createSocket(0x00);
     /* Initialize the Frame Receiver */
-    frameReceiver = new ReceiveFrames(canInterface->getSocketEcuRead(), moduleId);
+    frameReceiver = new ReceiveFrames(battery_socket, moduleId);
 
     LOG_INFO(batteryModuleLogger.GET_LOGGER(), "Battery object created successfully using Parameterized Constructor, ID : 0x{:X}", this->moduleId);
 
-    /* Send Up-Notification to MCU */
+    /* Send Up-Notification to MCU */ 
     sendNotificationToMCU();
 }
 
@@ -52,7 +54,7 @@ BatteryModule::~BatteryModule()
 void BatteryModule::sendNotificationToMCU()
 {
     /* Create an instance of GenerateFrames with the CAN socket */
-    GenerateFrames notifyFrame = GenerateFrames(canInterface->getSocketEcuRead(), batteryModuleLogger);
+    GenerateFrames notifyFrame = GenerateFrames(battery_socket, batteryModuleLogger);
 
     /* Create a vector of uint8_t (bytes) containing the data to be sent */
     std::vector<uint8_t> data = {0x0, 0xff, 0x11, 0x3};
@@ -152,7 +154,6 @@ void BatteryModule::fetchBatteryData()
     {
         /* Execute the shell command to read System Info about Battery */
         std::string data = exec("upower -i /org/freedesktop/UPower/devices/battery_BAT0");
-
         /* Call the function in order to parse the datas */
         parseBatteryInfo(data, energy, voltage, percentage, state);
 
@@ -176,7 +177,7 @@ void BatteryModule::receiveFrames()
     LOG_INFO(batteryModuleLogger.GET_LOGGER(), "Battery module starts the frame receiver");
 
     /* Create a HandleFrames object to process received frames */
-    HandleFrames handleFrames;
+    HandleFrames handleFrames(this->battery_socket);
 
     /* Receive a CAN frame using the frame receiver and process it with handleFrames */
     frameReceiver->receive(handleFrames);
@@ -213,4 +214,9 @@ float BatteryModule::getPercentage() const
 std::string BatteryModule::getLinuxBatteryState()
 {
     return state;
+}
+
+int BatteryModule::getBatterySocket() const
+{
+    return battery_socket;
 }

--- a/src/ecu_simulation/BatteryModule/src/ReceiveFrames.cpp
+++ b/src/ecu_simulation/BatteryModule/src/ReceiveFrames.cpp
@@ -163,7 +163,6 @@ void ReceiveFrames::bufferFrameOut(HandleFrames &handle_frame)
         }
         if (frame.data[1] == 0xAA)
         {
-            uint8_t frame_dest_id = frame.can_id & 0xFF;
             current_module_id = frame_id & 0xFF;
             GenerateFrames test =GenerateFrames(this->socket, batteryModuleLogger);
             std::vector<uint8_t> data = {0x00, 0xAA};

--- a/src/mcu/Makefile
+++ b/src/mcu/Makefile
@@ -1,11 +1,11 @@
 #Compiler flags
-CFLAGS = -g -Wall -pthread -I./include -I./src -I../utils/include -I../utils/src -I../uds/diagnostic_session_control/include -I../uds/diagnostic_session_control/src
+CFLAGS = -std=c++17 -g -Wall -pthread -I./include -I./src -I../utils/include -I../utils/src -I../uds/diagnostic_session_control/include -I../uds/diagnostic_session_control/src
 CFLAGSTST = -std=c++17 -I/include
 CFLAGSTST2 = -lgtest -lgtest_main -lpthread
 LDFLAGS = -lspdlog
 CFLAGSTST += -DUNIT_TESTING_MODE
 #Sources files
-SRCS = src/main.cpp src/MCUModule.cpp ../ecu_simulation/BatteryModule/src/BatteryModule.cpp ../utils/src/GenerateFrames.cpp src/HandleFrames.cpp ../utils/src/CreateInterface.cpp ../uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp src/ReceiveFrames.cpp ../uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp ../uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp ../uds/ecu_reset/src/EcuReset.cpp ../uds/authentication/src/SecurityAccess.cpp  ../ecu_simulation/BatteryModule/src/HandleFrames.cpp  ../ecu_simulation/BatteryModule/src/ReceiveFrames.cpp .../uds/read_dtc_information/src/ReadDtcInformation.cpp ../ota/request_update_status/src/RequestUpdateStatus.cpp ../ota/request_transfer_exit/src/RequestTransferExit.cpp ../ota/request_download/src/RequestDownload.cpp
+SRCS = src/main.cpp src/MCUModule.cpp ../ecu_simulation/BatteryModule/src/BatteryModule.cpp ../utils/src/GenerateFrames.cpp src/HandleFrames.cpp ../utils/src/CreateInterface.cpp ../uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp src/ReceiveFrames.cpp ../uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp ../uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp ../uds/ecu_reset/src/EcuReset.cpp ../uds/authentication/src/SecurityAccess.cpp  ../ecu_simulation/BatteryModule/src/HandleFrames.cpp  ../ecu_simulation/BatteryModule/src/ReceiveFrames.cpp ../uds/read_dtc_information/src/ReadDtcInformation.cpp ../ota/request_update_status/src/RequestUpdateStatus.cpp ../ota/request_transfer_exit/src/RequestTransferExit.cpp ../ota/request_download/src/RequestDownload.cpp
 SRCSTEST = src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp ../utils/src/Logger.cpp  ../uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp ../uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp ../uds/ecu_reset/src/EcuReset.cpp ../uds/authentication/src/SecurityAccess.cpp ../ecu_simulation/BatteryModule/src/HandleFrames.cpp ../ecu_simulation/BatteryModule/src/ReceiveFrames.cpp ../ecu_simulation/BatteryModule/src/BatteryModule.cpp ../uds/read_dtc_information/src/ReadDtcInformation.cpp ../ota/request_update_status/src/RequestUpdateStatus.cpp ../ota/request_transfer_exit/src/RequestTransferExit.cpp ../ota/request_download/src/RequestDownload.cpp
 #Object files
 OBJS = $(patsubst ../utils/src/%.cpp ../uds/diagnostic_session_control/src/%.cpp src/%.cpp, obj/%.o, $(SRCS))
@@ -47,7 +47,7 @@ $(OBJ_DIR)/RequestDownload.o: ../ota/request_download/src/RequestDownload.cpp
 $(OBJ_DIR)/RequestUpdateStatus.o: ../ota/request_update_status/src/RequestUpdateStatus.cpp
 	$(CXX) $(CFLAGS) -c ../ota/request_update_status/src/RequestUpdateStatus.cpp -o $(OBJ_DIR)/RequestUpdateStatus.o
 clean:
-	rm -f $(FINAL)  ${FINAL_TEST} ../utils/test/GenerateFramesTest test/HandleFrames_test test/ReceiveFramesTest ../utils/test/CreateInterface_test ../uds/write_data_by_identifier/utest/WriteDataByIdentifierTest.cpp
+	rm -f $(FINAL)  ${FINAL_TEST} ../utils/test/GenerateFramesTest test/HandleFrames_test test/ReceiveFramesTest ../utils/test/CreateInterface_test ../uds/write_data_by_identifier/utest/WriteDataByIdentifierTest ../uds/read_data_by_identifier/utest/ReadDataByIdentifierTest
 	rm -rf $(OBJ_DIR)
 #Delete unnecessary file from gcov compiler
 	find . -name '*.gcno' -delete
@@ -83,7 +83,7 @@ GenerateFrames_test: ../utils/test/GenerateFramesTest.cpp ../utils/src/GenerateF
 # CreateInterface Unit tests
 createInterfaceTest: CreateInterface_test
 CreateInterface_test: ../utils/test/CreateInterface_test.cpp ../utils/src/CreateInterface.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
 
 # ReadDataByIdentifier Unit tests
 RDBITest: ReadDataByIdentifier_test
@@ -146,7 +146,7 @@ GenerateFramesCoverage: ../utils/test/GenerateFramesTest.cpp ../utils/src/Genera
 # CreateInterface Coverage
 createInterfaceCoverage: CreateInterfaceCoverage
 CreateInterfaceCoverage: ../utils/test/CreateInterface_test.cpp ../utils/src/CreateInterface.cpp
-	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
+	  $(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
 	./../utils/test/CreateInterface_test
 	mkdir -p coverage/out_CreateInterface
 	gcov -o . ../utils/src/CreateInterface.cpp
@@ -215,7 +215,7 @@ GenerateFrames_coverage:
 	mv GenerateFrames.cpp.gcov coverage/out_GenerateFrames
 
 CreateInterface_coverage:
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp $(SRCSTEST) $(CFLAGSTST2) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -fprofile-arcs -ftest-coverage -o ../utils/test/CreateInterface_test ../utils/test/CreateInterface_test.cpp ../utils/src/CreateInterface.cpp ../utils/src/Logger.cpp $(CFLAGSTST2) $(LDFLAGS)
 	./../utils/test/CreateInterface_test
 	mkdir -p coverage/out_CreateInterface
 	gcov -o . ../utils/src/CreateInterface.cpp

--- a/src/mcu/include/HandleFrames.h
+++ b/src/mcu/include/HandleFrames.h
@@ -32,9 +32,12 @@ namespace MCU
     class HandleFrames 
     {
     private:
+        int socket_api = -1;
+        int socket_canbus = -1;
         DiagnosticSessionControl mcuDiagnosticSessionControl;
+        RequestDownloadService requestDownload;
     public:
-        HandleFrames() : mcuDiagnosticSessionControl(MCULogger) {};
+        HandleFrames(int socket_api, int socket_canbus);
         /**
          * @brief Method used to handle a can frame received from the ReceiveFrame class.
          * Takes a can_frame as parameter, checks if the frame is complete and then calls
@@ -61,9 +64,12 @@ namespace MCU
          * @param[in] nrc The negative response code.
          */
         void processNrc(canid_t frame_id, uint8_t sid, uint8_t nrc);
-      
-        private:
-        RequestDownloadService requestDownload;
+        /**
+         * @brief return the socket, either vcan1 socket or vcan0 socket
+         * @param[in] frame_id The frame ID used to determine the socket.
+         * @return int 
+         */
+        int getMcuSocket(canid_t frame_id);
     };
 }
 #endif /* HANDLE_FRAMES_H */

--- a/src/mcu/include/MCUModule.h
+++ b/src/mcu/include/MCUModule.h
@@ -77,6 +77,8 @@ namespace MCU
          * @return The current value of MCU state
          */
         void setMCUState(bool state);
+        int getMcuApiSocket() const;
+        int getMcuEcuSocket() const;
 
     private:
         bool is_running;
@@ -84,6 +86,8 @@ namespace MCU
         ReceiveFrames* receive_frames;
         std::vector<uint8_t> securityAccess_seed;
         bool mcu_state = false;
+        int mcu_api_socket = -1;
+        int mcu_ecu_socket = -1;
     };
 extern MCUModule mcu;
 }

--- a/src/mcu/src/MCUModule.cpp
+++ b/src/mcu/src/MCUModule.cpp
@@ -10,18 +10,20 @@ namespace MCU
     MCUModule mcu(0x01);
     /* Constructor */
     MCUModule::MCUModule(uint8_t interfaces_number) : 
-                    create_interface(CreateInterface::getInstance(interfaces_number, MCULogger)),
                     is_running(false),
-                    receive_frames(nullptr) 
+                    create_interface(CreateInterface::getInstance(interfaces_number, MCULogger)),
+                    receive_frames(nullptr),
+                    mcu_api_socket(create_interface->createSocket(interfaces_number)),
+                    mcu_ecu_socket(create_interface->createSocket(interfaces_number >> 4))
                     {
-        receive_frames = new ReceiveFrames(create_interface->getSocketEcuRead(), create_interface->getSocketApiRead());
+        receive_frames = new ReceiveFrames(mcu_ecu_socket, mcu_api_socket);
 
     }
 
     /* Default constructor */
-    MCUModule::MCUModule() : create_interface(CreateInterface::getInstance(0x01, MCULogger)),
-                                                is_running(false),
-                                                receive_frames(nullptr) {}
+    MCUModule::MCUModule() : is_running(false),
+                         create_interface(CreateInterface::getInstance(0x01, MCULogger)),
+                         receive_frames(nullptr) {}
 
     /* Destructor */
     MCUModule::~MCUModule() 
@@ -55,6 +57,14 @@ namespace MCU
     void MCUModule::setMCUState(bool state)
     {
         mcu_state = state;
+    }
+    int MCUModule::getMcuApiSocket() const 
+    {
+    return mcu_api_socket;
+    }
+    int MCUModule::getMcuEcuSocket() const 
+    {
+    return mcu_ecu_socket;
     }
 
 

--- a/src/mcu/src/ReceiveFrames.cpp
+++ b/src/mcu/src/ReceiveFrames.cpp
@@ -2,8 +2,10 @@
 namespace MCU
 {
     ReceiveFrames::ReceiveFrames(int socket_canbus, int socket_api)
-        : socket_canbus(socket_canbus), socket_api(socket_api), generate_frames(socket_canbus, MCULogger),
-        timeout_duration(120), running(true) 
+        : timeout_duration(120), running(true), socket_canbus(socket_canbus), 
+        socket_api(socket_api), handler(socket_api, socket_canbus),
+        generate_frames(socket_canbus, MCULogger)
+        
     {
         startTimerThread();
     }
@@ -272,7 +274,6 @@ namespace MCU
                 std::lock_guard<std::mutex> lock(queue_mutex);
                 for (auto it = ecu_timers.begin(); it != ecu_timers.end();) {
                     if (std::chrono::duration_cast<std::chrono::seconds>(now - it->second) >= timeout_duration) {
-                        uint8_t ecu_id = it->first;
                         /* Send request frame */
                         std::vector<uint8_t> data = {0x01};
                         ReceiveFrames::generate_frames.sendFrame(0x1011, data);

--- a/src/ota/request_download/include/RequestDownload.h
+++ b/src/ota/request_download/include/RequestDownload.h
@@ -19,13 +19,13 @@ public:
      * @brief Construct a new Request Download Service object
      * 
      */
-    RequestDownloadService();
+    RequestDownloadService(Logger& RDSlogger);
     /**
      * @brief Construct a new Request Download Service object with Logger
      * 
      * @param RDSlogger 
      */
-    RequestDownloadService(Logger& RDSlogger);
+    RequestDownloadService(int socket, Logger& RDSlogger);
     /**
      * @brief Destroy the Request Download Service object
      * 
@@ -48,16 +48,12 @@ public:
      */
     void requestDownloadResponse(int id, uint8_t length_max_number_block, int max_number_block, Logger &RDSlogger);
 private:
+    int socket = -1;
     /**
      * @brief 
      * 
      */
     GenerateFrames generateFrames;
-    /**
-     * @brief 
-     * 
-     */
-    CreateInterface* create_interface;
     /**
      * @brief Method for checking if the MCU is in the programming session
      * 

--- a/src/ota/request_update_status/include/RequestUpdateStatus.h
+++ b/src/ota/request_update_status/include/RequestUpdateStatus.h
@@ -25,8 +25,7 @@
 #include <linux/can.h>
 #include <map>
 #include "../../../utils/include/Logger.h"
-// #include "../../../uds/read_data_by_identifier/include/read_data_by_identifier.h"
-#include "../../../utils/include/CreateInterface.h"
+/* #include "../../../uds/read_data_by_identifier/include/read_data_by_identifier.h" */
 #include "../../../utils/include/GenerateFrames.h"
 
 #define REQUEST_UPDATE_STATUS_REQUEST_SIZE      0x02
@@ -86,9 +85,9 @@ class RequestUpdateStatus
 {
 private:        
 	Logger _logger;
-    CreateInterface* create_interface;
+	int socket = -1;
 public:
-	RequestUpdateStatus(Logger logger);
+	RequestUpdateStatus(int socket, Logger logger);
 	~RequestUpdateStatus();
 	/**
 	 * @brief Service method. Receive a request for reading Ota Update Status.

--- a/src/ota/request_update_status/src/RequestUpdateStatus.cpp
+++ b/src/ota/request_update_status/src/RequestUpdateStatus.cpp
@@ -11,11 +11,8 @@
 
 #include "../include/RequestUpdateStatus.h"
 
-RequestUpdateStatus::RequestUpdateStatus(Logger logger) : _logger{logger}
-{
-    /* Interface needed for sending the response. */
-    create_interface = create_interface->getInstance(0x00, _logger);
-}
+RequestUpdateStatus::RequestUpdateStatus(int socket, Logger logger) : _logger{logger}, socket(socket)
+{}
 
 void RequestUpdateStatus::requestUpdateStatus(canid_t request_id, std::vector<uint8_t> request)
 {
@@ -60,8 +57,8 @@ void RequestUpdateStatus::requestUpdateStatus(canid_t request_id, std::vector<ui
         RUS_response.push_back(RIDB_response[4]);                   /* OTA UPDATE STATUS */
     }
 
-    GenerateFrames generate_frames(create_interface->getSocketApiWrite(), _logger);
-    generate_frames.sendFrame(response_id, RUS_response);
+    // GenerateFrames generate_frames(MCU::mcu.getMcuApiSocket(), _logger);
+    // generate_frames.sendFrame(response_id, RUS_response);
 }
 
 

--- a/src/uds/authentication/include/SecurityAccess.h
+++ b/src/uds/authentication/include/SecurityAccess.h
@@ -11,7 +11,6 @@
 #include <iomanip>
 #include <random>
 
-#include "../../../utils/include/CreateInterface.h"
 #include "../../../utils/include/GenerateFrames.h"
 #include "../../utils/include/Logger.h"
 
@@ -42,9 +41,9 @@ class SecurityAccess
     /**
     * @brief Default constructor
     */
-    SecurityAccess();
+    SecurityAccess(int socket, Logger& security_logger);
 
-    void securityAccess(canid_t can_id, const std::vector<uint8_t>& data, Logger& securityLogger);
+    void securityAccess(canid_t can_id, const std::vector<uint8_t>& data);
 
     std::vector<uint8_t> computeKey(const std::vector<uint8_t>& seed);
 
@@ -52,7 +51,8 @@ class SecurityAccess
 
     private:
     GenerateFrames* generate_frames;
-    CreateInterface* create_interface;
+    Logger& security_logger;
+    int socket = -1;
 
 };
 

--- a/src/uds/authentication/src/SecurityAccess.cpp
+++ b/src/uds/authentication/src/SecurityAccess.cpp
@@ -1,7 +1,8 @@
 #include "../include/SecurityAccess.h"
 #include "../../../mcu/include/MCUModule.h"
 
-SecurityAccess::SecurityAccess()
+SecurityAccess::SecurityAccess(int socket, Logger& security_logger)
+                :  security_logger(security_logger), socket(socket)
 {}
 
 std::vector<uint8_t> SecurityAccess::computeKey(const std::vector<uint8_t>& seed)
@@ -34,7 +35,7 @@ std::vector<uint8_t> SecurityAccess::generateRandomBytes(size_t length)
     return bytes;
 }
 
-void SecurityAccess::securityAccess(canid_t can_id, const std::vector<uint8_t>& request, Logger& security_logger)
+void SecurityAccess::securityAccess(canid_t can_id, const std::vector<uint8_t>& request)
 {
     std::vector<uint8_t> response;
     std::vector<uint8_t> key;
@@ -47,10 +48,7 @@ void SecurityAccess::securityAccess(canid_t can_id, const std::vector<uint8_t>& 
     can_id = ((lowerbits << 8) | upperbits);
     if (upperbits == 0xFA) 
     {
-        create_interface = create_interface->getInstance(0x00, security_logger);
-        if (create_interface) 
-        {
-            generate_frames = new GenerateFrames(create_interface->getSocketApiWrite(), security_logger);
+            generate_frames = new GenerateFrames(socket, security_logger);
 
             /* Incorrect message length or invalid format */
             if ((request.size() < 3) ||
@@ -140,5 +138,4 @@ void SecurityAccess::securityAccess(canid_t can_id, const std::vector<uint8_t>& 
             /* Handle the case where create_interface is null */
             LOG_ERROR(security_logger.GET_LOGGER(), "Create_interface is nullptr");
         }
-    }
-}
+} 

--- a/src/uds/diagnostic_session_control/include/DiagnosticSessionControl.h
+++ b/src/uds/diagnostic_session_control/include/DiagnosticSessionControl.h
@@ -2,10 +2,8 @@
 #define DIAGNOSTICSESSIONCONTROL_H
 
 #include <cstdlib>
-#include "../../../utils/include/CreateInterface.h"
 #include "../../../utils/include/GenerateFrames.h"
 #include "../../../utils/include/Logger.h"
-
 /* Diagnostic Control Session codes */
 const uint8_t SID_DIAGNOSTIC_SESSION_CONTROL = 0x10;
 const uint8_t SUB_FUNCTION_DEFAULT_SESSION = 1;
@@ -31,7 +29,7 @@ public:
      * this will be used in MCU module.
      * 
      */
-    DiagnosticSessionControl(Logger logger);
+    DiagnosticSessionControl(Logger logger, int socket);
     /**
      * @brief Construct a new Diagnostic Session Control object
      * with a parameter given for 'module_id'. For example, battery
@@ -39,7 +37,7 @@ public:
      * 
      * @param module_id 
      */
-    DiagnosticSessionControl(int module_id, Logger logger);
+    DiagnosticSessionControl(int module_id, Logger logger, int socket);
     ~DiagnosticSessionControl();
 
     /**
@@ -48,7 +46,7 @@ public:
      * @param id 
      * @param sub_function 
      */
-    void sessionControl(int id, int sub_function);
+    void sessionControl(uint8_t id, uint8_t sub_function);
 
     /**
      * @brief Method to handle the Request for switching the Sessions
@@ -75,9 +73,9 @@ public:
 private:
     int module_id;
     Logger dsc_logger;
-    CreateInterface *can_interface;
     DiagnosticSession current_session;
     void switchToDefaultSession();
+    int socket = -1;
 
     /**
      * @brief Method to handle the negative responses,

--- a/src/uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp
+++ b/src/uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp
@@ -2,20 +2,19 @@
 #include <iostream>
 
 /* Default constructor, used in MCU */
-DiagnosticSessionControl::DiagnosticSessionControl(Logger logger) : dsc_logger(logger),
-                                                                    current_session(DEFAULT_SESSION),
-                                                                    can_interface(CreateInterface::getInstance(0x00, dsc_logger)),
-                                                                    module_id(module_id)
+DiagnosticSessionControl::DiagnosticSessionControl(Logger logger, int socket) : dsc_logger(logger),
+                                                                    current_session(DEFAULT_SESSION)
 {
+    this->socket = socket;
     LOG_INFO(dsc_logger.GET_LOGGER(), "Diagnostic Session Control (0x10) started. Current session: {}", getCurrentSessionToString());
 }
 
 /* Parameterized constructor, used for ECUs */
-DiagnosticSessionControl::DiagnosticSessionControl(int module_id, Logger logger) : dsc_logger(logger),
-                                                                                   current_session(DEFAULT_SESSION),
-                                                                                   can_interface(CreateInterface::getInstance(0x00, dsc_logger)),
-                                                                                   module_id(module_id)
+DiagnosticSessionControl::DiagnosticSessionControl(int module_id, Logger logger, int socket) : module_id(module_id), 
+                                                                                   dsc_logger(logger),
+                                                                                   current_session(DEFAULT_SESSION)
 {
+    this->socket = socket;
     LOG_INFO(dsc_logger.GET_LOGGER(), "Diagnostic Session Control (0x10) started. Current session: {}", getCurrentSessionToString());
 }
 
@@ -25,7 +24,7 @@ DiagnosticSessionControl::~DiagnosticSessionControl()
 }
 
 /* Method to control the sessions of service */
-void DiagnosticSessionControl::sessionControl(int id, int sub_function)
+void DiagnosticSessionControl::sessionControl(uint8_t id, uint8_t sub_function)
 {
     uint8_t request[] = {id, sub_function};
     size_t requestLength = sizeof(request) / sizeof(request[0]);
@@ -97,7 +96,7 @@ void DiagnosticSessionControl::switchToDefaultSession()
     LOG_INFO(dsc_logger.GET_LOGGER(), "Switched to Default Session. Current session: {}", getCurrentSessionToString());
 
     /* Create instance of Generate Frames to send response frame */
-    GenerateFrames response_frame(can_interface->getSocketEcuWrite(), dsc_logger);
+    GenerateFrames response_frame(socket, dsc_logger);
 
     /** Check the module where the request was made from
      * More ECUs can be added here in future.

--- a/src/uds/ecu_reset/include/EcuReset.h
+++ b/src/uds/ecu_reset/include/EcuReset.h
@@ -24,6 +24,7 @@ class EcuReset
 private:
     uint32_t can_id;
     uint8_t sub_function;
+    int socket = -1;
     
     Logger& ECUResetLog;
     GenerateFrames generate_frames;

--- a/src/uds/ecu_reset/src/EcuReset.cpp
+++ b/src/uds/ecu_reset/src/EcuReset.cpp
@@ -3,7 +3,7 @@
 EcuReset::EcuReset(uint32_t can_id, uint8_t sub_function, int socket, Logger &logger)
     : can_id(can_id), sub_function(sub_function), ECUResetLog(logger), generate_frames(socket, logger)
 {
-    interface = CreateInterface::getInstance(0x00, logger);
+    this->socket = socket;
 }
 
 EcuReset::~EcuReset()
@@ -70,5 +70,5 @@ void EcuReset::ecuResetResponse()
     can_id = (frame_sender_id << 8) | frame_dest_id;
     LOG_INFO(ECUResetLog.GET_LOGGER(), "can_id = 0x{0:x}", can_id);
 
-    generate_frames.ecuReset(can_id, sub_function, generate_frames.getSocket(), true);
+    generate_frames.ecuReset(can_id, sub_function, socket, true);
 }

--- a/src/uds/read_data_by_identifier/include/ReadDataByIdentifier.h
+++ b/src/uds/read_data_by_identifier/include/ReadDataByIdentifier.h
@@ -28,18 +28,19 @@ class ReadDataByIdentifier
     /**
     * @brief Default constructor
     */
-    ReadDataByIdentifier();
+    ReadDataByIdentifier(int socket, Logger& rdbi_logger);
     /**
     * @brief Method that retrieves some data based on a DID.
     * @param can_id The frame id.
     * @param request Data from a can frame that contains PCI, SID and DID
-    * @param RDBILogger Logger reference to log in a specific file.
+    * @param use_send_frame true if you want to send a response frame, false if you need only the return
     */
-    std::vector<uint8_t> readDataByIdentifier(canid_t can_id, const std::vector<uint8_t>& request, Logger& RDBILogger);
+    std::vector<uint8_t> readDataByIdentifier(canid_t can_id, const std::vector<uint8_t>& request, bool use_send_frame);
     
     private:
-    GenerateFrames* generate_frames;
-    CreateInterface* create_interface;
+    GenerateFrames generate_frames;
+    int socket = -1;
+    Logger& rdbi_logger;
 
 };
 

--- a/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
+++ b/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
@@ -2,20 +2,23 @@
 #include "../../../ecu_simulation/BatteryModule/include/BatteryModule.h"
 #include "../../../mcu/include/MCUModule.h"
 
-ReadDataByIdentifier::ReadDataByIdentifier()
-{}
+ReadDataByIdentifier::ReadDataByIdentifier(int socket, Logger& rdbi_logger) 
+            : generate_frames(socket, rdbi_logger), rdbi_logger(rdbi_logger)
+{
+    this->socket = socket;
+}
 
 /* Define the service identifier for Read Data By Identifier */
 const uint8_t RDBI_SERVICE_ID = 0x22;
 
 /* Function to handle the Read Data By Identifier request */
-std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, const std::vector<uint8_t>& request, Logger& rdbi_logger) {
+std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, const std::vector<uint8_t>& request, bool use_send_frame) {
     std::vector<uint8_t> response;
 
     /* Extract the first 8 bits of can_id */
     uint8_t lowerbits = can_id & 0xFF;
     uint8_t upperbits = can_id >> 8 & 0xFF;
-
+    LOG_INFO(rdbi_logger.GET_LOGGER(), "Log in serviciu RDBI");
     /* Check if the request size is less than 4 */
     if (request.size() < 4) {
         /* Invalid request length - prepare a negative response */
@@ -24,23 +27,12 @@ std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, 
         response.push_back(RDBI_SERVICE_ID); /* Service ID */
         response.push_back(0x13); /* Incorrect message length or invalid format */
 
-        /* Send the response frame to the bus */
-        create_interface = create_interface->getInstance(0x00, rdbi_logger);
-        if (create_interface) 
-        {
-            /* Send to API or canbus based on the upperbits(sender) */
-            generate_frames = new GenerateFrames(
-                (upperbits == 0xFA) ? create_interface->getSocketApiWrite() : create_interface->getSocketEcuWrite(),
-                rdbi_logger);
-                /* Send the negative response frame */ 
-                /* this will be replaced by NegativeResponse when done */
-                generate_frames->readDataByIdentifier(can_id, 0, response);
+        if (use_send_frame) {
+            /* Send the negative response frame */ 
+            /* this will be replaced by NegativeResponse when done */
+            generate_frames.readDataByIdentifier(can_id, 0, response);
         }
-        else
-        {
-            /* Handle the case where create_interface is null */
-            LOG_ERROR(rdbi_logger.GET_LOGGER(), "create_interface is nullptr");
-        }
+
         /* Return early as the request is invalid */
         return response;
     }
@@ -51,56 +43,29 @@ std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, 
     /* Reverse IDs */
     can_id = ((lowerbits << 8) | upperbits);
 
-    /* Vector to store data from ecuData */
-    std::vector<uint8_t> stored_data;
-
     /* Determine which ECU data storage to use based on the first 8 bits of can_id */
     if ((lowerbits == 0x10 && MCU::mcu.mcu_data.find(data_identifier) != MCU::mcu.mcu_data.end()) ||
         (lowerbits == 0x11 && battery.ecu_data.find(data_identifier) != battery.ecu_data.end())) {
 
         /* Fetch the data based on the data identifier */
         if (lowerbits == 0x10) {
-            stored_data = MCU::mcu.mcu_data.at(data_identifier);
+            response = MCU::mcu.mcu_data.at(data_identifier);
         } else {
             battery.fetchBatteryData();
-            stored_data = battery.ecu_data.at(data_identifier);
+            response = battery.ecu_data.at(data_identifier);
         }
-
-        /* Prepare a positive response */
-        response.clear();
-        response.push_back(0x03); /* PCI */
-        response.push_back(0x62); /* Response SID = Initial SID + 0x40 */
-        response.push_back(request[2]); /* Data identifier, two bytes */
-        response.push_back(request[3]);
-        response.insert(response.end(), stored_data.begin(), stored_data.end());
 
     } else {
         /* Data identifier not found */
-        /* response.push_back(0x03); */
-        /* response.push_back(0x7F); */ /* Negative response */
-        /* response.push_back(RDBI_SERVICE_ID); */
-        /* response.push_back(0x31); */ /* Request out of range */
-        /* 0x31 NRC is not yet defined so I log it instead */
         LOG_ERROR(rdbi_logger.GET_LOGGER(), "Request out of range");
     }
 
-    /* Check if sender was API so MCU will send directly to API */
-    create_interface = create_interface->getInstance(0x00, rdbi_logger);
-    if (create_interface) {
-        generate_frames = new GenerateFrames(
-            (upperbits == 0xFA) ? create_interface->getSocketApiWrite() : create_interface->getSocketEcuWrite(),
-            rdbi_logger
-        );
-
-        if (response.size() > 8) {
-            generate_frames->readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
+    if (use_send_frame) {
+        if (response.size() > 7) {
+            generate_frames.readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
         } else {
-            generate_frames->readDataByIdentifier(can_id, data_identifier, response);
+            generate_frames.readDataByIdentifier(can_id, data_identifier, response);
         }
-    } else {
-        /* Handle the case where create_interface is null */
-        LOG_ERROR(rdbi_logger.GET_LOGGER(), "create_interface is nullptr");
     }
-
     return response;
 }

--- a/src/uds/read_dtc_information/include/ReadDtcInformation.h
+++ b/src/uds/read_dtc_information/include/ReadDtcInformation.h
@@ -12,7 +12,6 @@
 #define READ_DTC_INFROMATION_H
 
 #include "../../../utils/include/GenerateFrames.h"
-#include "../../utils/include/CreateInterface.h"
 
 #include <iostream>
 #include <fstream>
@@ -30,10 +29,8 @@ class ReadDTC
     private:
         std::string path_folder;
         GenerateFrames* generate;
-        int socket_read;
-        int socket_write;
+        int socket;
         Logger logger;
-        CreateInterface* interface;
 
     public:
         /**
@@ -41,7 +38,7 @@ class ReadDTC
          * 
          * @param path_folder path to the file containing the dtcs
          */
-        ReadDTC(Logger logger, std::string path_folder = "default");
+        ReadDTC(Logger logger, std::string path_folder, int socket);
         /**
          * @brief Destroy the Read DTC object
          * 
@@ -92,13 +89,6 @@ class ReadDTC
          * @return int 
          */
         int dtc_to_hex(std::string dtc);
-        /**
-         * @brief Set the Socket_ object
-         * 
-         * @param id 
-         * @return int 
-         */
-        int SetSockets_(int id);
 };
 
 #endif

--- a/src/uds/write_data_by_identifier/include/WriteDataByIdentifier.h
+++ b/src/uds/write_data_by_identifier/include/WriteDataByIdentifier.h
@@ -21,7 +21,6 @@
 #include<linux/can.h>
 #include <unordered_set>
 
-#include "../../../utils/include/CreateInterface.h"
 #include "../../../utils/include/GenerateFrames.h"
 #include "../../../utils/include/Logger.h"
 
@@ -32,7 +31,8 @@ class WriteDataByIdentifier
 {
 private:
     GenerateFrames generate_frames;
-    CreateInterface* create_interface;
+    int socket = -1;
+    Logger& wdbi_logger;
 
 public:
     /**
@@ -42,7 +42,7 @@ public:
      * @param frame_data 
      * @param WDBILogger 
      */
-    WriteDataByIdentifier(canid_t frame_id, std::vector<uint8_t> frame_data, Logger& WDBILogger);
+    WriteDataByIdentifier(canid_t frame_id, std::vector<uint8_t> frame_data, Logger& wdbi_logger, int socket);
     /**
      * @brief Destroy the Write Data By Identifier object
      * 
@@ -56,9 +56,8 @@ public:
      * 
      * @param frame_id 
      * @param frame_data 
-     * @param WDBILogger 
      */
-    void WriteDataByIdentifierService(canid_t frame_id, std::vector<uint8_t> frame_data, Logger& WDBILogger);
+    void WriteDataByIdentifierService(canid_t frame_id, std::vector<uint8_t> frame_data);
 };
 
 #endif

--- a/src/utils/include/CreateInterface.h
+++ b/src/utils/include/CreateInterface.h
@@ -43,10 +43,6 @@ class CreateInterface
         uint8_t interface_name;        
         struct sockaddr_can addr;
         struct ifreq ifr;
-        int socket_ecu_read = -1;
-        int socket_api_read = -1;
-        int socket_ecu_write = -1;
-        int socket_api_write = -1;
         Logger& logger;
 
     public:
@@ -62,12 +58,13 @@ class CreateInterface
          */
         uint8_t getInterfaceName();
 
+        int createSocket(uint8_t interface_number);
         /**
         * @brief Set the socket to not block in the reading operation.
-        * 
+        * @param socket socket file descriptor needed to be set as non blocking
         * @return int 
         */
-        int setSocketBlocking();
+        int setSocketBlocking(int socket);
         /**
         * @brief Method to create vcan interfaces: one to communicate 
         * with ECU and one to communicate with API
@@ -95,24 +92,6 @@ class CreateInterface
         * @return Returns true if interfaces were deleted and false if an error was encountered. 
         */    
         bool deleteInterface();
-
-        /**
-        * @brief Method that returns ECU socket for read
-        */  
-        int getSocketEcuRead();
-        /**
-        * @brief Method that returns API socket for read
-        */  
-        int getSocketApiRead();
-        /**
-        * @brief Method that returns ECU socket for write
-        */  
-        int getSocketEcuWrite();
-        /**
-        * @brief Method that returns API socket for write
-        */  
-        int getSocketApiWrite();
-
         friend class EcuReset;
 };
 

--- a/src/utils/include/GenerateFrames.h
+++ b/src/utils/include/GenerateFrames.h
@@ -38,7 +38,7 @@ class GenerateFrames
         Logger& logger;
         int socket = -1;
     public:
-        GenerateFrames();
+        GenerateFrames(Logger& logger);
   
         /**
          * @brief Construct a new Generate Frames object

--- a/src/utils/src/GenerateFrames.cpp
+++ b/src/utils/src/GenerateFrames.cpp
@@ -1,6 +1,6 @@
 #include "../include/GenerateFrames.h"
 
-GenerateFrames::GenerateFrames()
+GenerateFrames::GenerateFrames(Logger& logger)
     : logger(logger)
 {}
 GenerateFrames::GenerateFrames(int socket, Logger& logger)
@@ -19,6 +19,12 @@ struct can_frame GenerateFrames::createFrame(int &id,  std::vector<uint8_t> &dat
     struct can_frame frame;
     switch (frameType)
     {
+        case ERROR_FRAME:
+        /* Handle ERROR_FRAME */
+        break;
+        case OVERLOAD_FRAME:
+        /* Handle OVERLOAD_FRAME */
+        break;
         case DATA_FRAME:
             frame.can_id = (id & CAN_EFF_MASK) | CAN_EFF_FLAG;
             frame.can_dlc = data.size();

--- a/src/utils/test/CreateInterface_test.cpp
+++ b/src/utils/test/CreateInterface_test.cpp
@@ -123,30 +123,13 @@ TEST(InterfaceTestSuite, ErrorDeleteInterfaceTest)
     EXPECT_NE(output.find("Error when trying to delete the first interface"), std::string::npos);
     EXPECT_NE(output.find("Error when trying to delete the second interface"), std::string::npos);       
 }
-   
-/* test the getSocketEcuRead method */
-TEST(InterfaceTestSuite, GetSocketECU)
-{    
-    CreateInterface* interface = CreateInterface::getInstance(0x01, logger);   
-    EXPECT_TRUE(is_valid_socket(interface->getSocketEcuRead()));  
-    /* clean up any existing interface to ensure a clean test environment for the next test */ 
-    interface->deleteInterface();
-}
-
-/* test the getSocketApiRead method */
-TEST(InterfaceTestSuite, GetSocketAPI)
-{    
-    CreateInterface* interface = CreateInterface::getInstance(0x01, logger);   
-    EXPECT_TRUE(is_valid_socket(interface->getSocketApiRead()));  
-    /* clean up any existing interface to ensure a clean test environment for the next test */ 
-    interface->deleteInterface();
-}
 
 /* test the setSocketBlocking method */
 TEST(InterfaceTestSuite, setSocketBlocking)
 {    
-    CreateInterface* interface = CreateInterface::getInstance(0x01, logger);   
-    EXPECT_EQ(interface->setSocketBlocking(), 0 ); 
+    CreateInterface* interface = CreateInterface::getInstance(0x01, logger);
+    int socket = interface->createSocket(0x01);
+    EXPECT_EQ(interface->setSocketBlocking(socket),0); 
     /* clean up any existing interface to ensure a clean test environment for the next test */ 
     interface->deleteInterface(); 
 }
@@ -156,8 +139,9 @@ TEST(InterfaceTestSuite, setSocketBlockingError)
 {    
     CreateInterface* interface = CreateInterface::getInstance(0x01, logger);       
     /* Close the file descriptor associated to the socket to simulate error */
-    close(interface->getSocketEcuRead());
-    EXPECT_EQ(interface->setSocketBlocking(), 1 ); 
+    int socket = interface->createSocket(0x01);
+    close(socket);
+    EXPECT_EQ(interface->setSocketBlocking(socket), 1); 
     /* clean up any existing interface to ensure a clean test environment for the next test */ 
     interface->deleteInterface();
 }


### PR DESCRIPTION
- Reworked CreateInterface so now every module can create its own socket and keep it alive until module shuts down, so each module is responsible for its socket
- This way, when you send a frame from an ecu, you won't receive the frame you sent, so buffer should be cleaner.
- Added getters in each module so you can access the module's socket.
- Modified RDBI service a bit to accept new socket format and also removed something I missed in the last PR.
- Removed SRCSTEST from createInterface makefile job, because it doesn't need all the files.

Now you don't need to access interface.getInstance in your service because it will be passed as argument when it is called in handleFrames.
Socket will be passed to handleFrames object from the module class, and when service will be called, that socket will be passed as argument.
On Mcu side, I added a method to determine which socket to use.

PR is into DEV_BE as these are common changes and I will merge them back to UDS and OTA.