### PR TITLE
Feature/ota integrate request update status

### DIFF
--- a/src/mcu/Makefile
+++ b/src/mcu/Makefile
@@ -5,7 +5,7 @@ CFLAGSTST2 = -lgtest -lgtest_main -lpthread
 LDFLAGS = -lspdlog
 CFLAGSTST += -DUNIT_TESTING_MODE
 #Sources files
-SRCS = src/main.cpp src/MCUModule.cpp ../ecu_simulation/BatteryModule/src/BatteryModule.cpp ../utils/src/GenerateFrames.cpp src/HandleFrames.cpp ../utils/src/CreateInterface.cpp ../uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp src/ReceiveFrames.cpp ../uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp ../uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp ../uds/ecu_reset/src/EcuReset.cpp ../uds/authentication/src/SecurityAccess.cpp  ../ecu_simulation/BatteryModule/src/HandleFrames.cpp  ../ecu_simulation/BatteryModule/src/ReceiveFrames.cpp .../uds/read_dtc_information/src/ReadDtcInformation.cpp ../ota/request_update_status/src/RequestUpdateStatus.cpp ../ota/request_transfer_exit/src/RequestTransferExit.cpp ../ota/request_download/src/RequestDownload.cpp
+SRCS = src/main.cpp src/MCUModule.cpp ../ecu_simulation/BatteryModule/src/BatteryModule.cpp ../utils/src/GenerateFrames.cpp src/HandleFrames.cpp ../utils/src/CreateInterface.cpp ../uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp src/ReceiveFrames.cpp ../uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp ../uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp ../uds/ecu_reset/src/EcuReset.cpp ../uds/authentication/src/SecurityAccess.cpp  ../ecu_simulation/BatteryModule/src/HandleFrames.cpp  ../ecu_simulation/BatteryModule/src/ReceiveFrames.cpp ../uds/read_dtc_information/src/ReadDtcInformation.cpp ../ota/request_update_status/src/RequestUpdateStatus.cpp ../ota/request_transfer_exit/src/RequestTransferExit.cpp ../ota/request_download/src/RequestDownload.cpp
 SRCSTEST = src/HandleFrames.cpp src/MCUModule.cpp src/ReceiveFrames.cpp ../utils/src/GenerateFrames.cpp ../utils/src/CreateInterface.cpp ../uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp ../utils/src/Logger.cpp  ../uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp ../uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp ../uds/ecu_reset/src/EcuReset.cpp ../uds/authentication/src/SecurityAccess.cpp ../ecu_simulation/BatteryModule/src/HandleFrames.cpp ../ecu_simulation/BatteryModule/src/ReceiveFrames.cpp ../ecu_simulation/BatteryModule/src/BatteryModule.cpp ../uds/read_dtc_information/src/ReadDtcInformation.cpp ../ota/request_update_status/src/RequestUpdateStatus.cpp ../ota/request_transfer_exit/src/RequestTransferExit.cpp ../ota/request_download/src/RequestDownload.cpp
 #Object files
 OBJS = $(patsubst ../utils/src/%.cpp ../uds/diagnostic_session_control/src/%.cpp src/%.cpp, obj/%.o, $(SRCS))
@@ -46,6 +46,7 @@ $(OBJ_DIR)/RequestDownload.o: ../ota/request_download/src/RequestDownload.cpp
 	$(CXX) $(CFLAGS) -c ../ota/request_download/src/RequestDownload.cpp -o $(OBJ_DIR)/RequestDownload.o
 $(OBJ_DIR)/RequestUpdateStatus.o: ../ota/request_update_status/src/RequestUpdateStatus.cpp
 	$(CXX) $(CFLAGS) -c ../ota/request_update_status/src/RequestUpdateStatus.cpp -o $(OBJ_DIR)/RequestUpdateStatus.o
+
 clean:
 	rm -f $(FINAL)  ${FINAL_TEST} ../utils/test/GenerateFramesTest test/HandleFrames_test test/ReceiveFramesTest ../utils/test/CreateInterface_test ../uds/write_data_by_identifier/utest/WriteDataByIdentifierTest.cpp
 	rm -rf $(OBJ_DIR)

--- a/src/mcu/include/MCUModule.h
+++ b/src/mcu/include/MCUModule.h
@@ -11,6 +11,7 @@
 #include "../../utils/include/CreateInterface.h"
 #include "ReceiveFrames.h"
 #include "../include/MCULogger.h"
+#include "../../uds/write_data_by_identifier/include/WriteDataByIdentifier.h"
 
 #include <thread>
 namespace MCU

--- a/src/mcu/src/HandleFrames.cpp
+++ b/src/mcu/src/HandleFrames.cpp
@@ -405,7 +405,7 @@ namespace MCU
                 else 
                 {
                     LOG_INFO(MCULogger.GET_LOGGER(), "RequestUpdateStatus called.");
-                    RequestUpdateStatus RUS(MCULogger);
+                    RequestUpdateStatus RUS;
                     RUS.requestUpdateStatus(frame_id, frame_data);
                 }
                 break;

--- a/src/mcu/src/MCUModule.cpp
+++ b/src/mcu/src/MCUModule.cpp
@@ -15,7 +15,7 @@ namespace MCU
                     receive_frames(nullptr) 
                     {
         receive_frames = new ReceiveFrames(create_interface->getSocketEcuRead(), create_interface->getSocketApiRead());
-
+        WriteDataByIdentifier WDBI(0x1111FA10, {0x07, 0x2A, 0x01, 0xE0, 0x30}, MCULogger);
     }
 
     /* Default constructor */

--- a/src/mcu/src/MCUModule.cpp
+++ b/src/mcu/src/MCUModule.cpp
@@ -15,7 +15,7 @@ namespace MCU
                     receive_frames(nullptr) 
                     {
         receive_frames = new ReceiveFrames(create_interface->getSocketEcuRead(), create_interface->getSocketApiRead());
-        WriteDataByIdentifier WDBI(0x1111FA10, {0x07, 0x2A, 0x01, 0xE0, 0x30}, MCULogger);
+        WriteDataByIdentifier WDBI(0x1111FA10, {PCI_L, WRITE_DATA_BY_IDENTIFIER_SID, OTA_UPDATE_STATUS_DID_MSB, OTA_UPDATE_STATUS_DID_LSB, IDLE}, MCULogger);
     }
 
     /* Default constructor */

--- a/src/mcu/src/MCUModule.cpp
+++ b/src/mcu/src/MCUModule.cpp
@@ -16,9 +16,9 @@ namespace MCU
                     mcu_api_socket(create_interface->createSocket(interfaces_number)),
                     mcu_ecu_socket(create_interface->createSocket(interfaces_number >> 4))
                     {
-                        
+
         receive_frames = new ReceiveFrames(mcu_ecu_socket, mcu_api_socket);
-        WriteDataByIdentifier WDBI(0x1111FA10, {PCI_L, WRITE_DATA_BY_IDENTIFIER_SID, OTA_UPDATE_STATUS_DID_MSB, OTA_UPDATE_STATUS_DID_LSB, IDLE}, MCULogger);
+        WriteDataByIdentifier WDBI(0x1111FA10, {PCI_L, WRITE_DATA_BY_IDENTIFIER_SID, OTA_UPDATE_STATUS_DID_MSB, OTA_UPDATE_STATUS_DID_LSB, IDLE}, MCULogger, mcu_api_socket);
     }
 
     /* Default constructor */

--- a/src/ota/request_update_status/include/RequestUpdateStatus.h
+++ b/src/ota/request_update_status/include/RequestUpdateStatus.h
@@ -25,7 +25,7 @@
 #include <linux/can.h>
 #include <map>
 #include "../../../utils/include/Logger.h"
-// #include "../../../uds/read_data_by_identifier/include/read_data_by_identifier.h"
+#include "../../../uds/read_data_by_identifier/include/ReadDataByIdentifier.h"
 #include "../../../utils/include/CreateInterface.h"
 #include "../../../utils/include/GenerateFrames.h"
 

--- a/src/ota/request_update_status/include/RequestUpdateStatus.h
+++ b/src/ota/request_update_status/include/RequestUpdateStatus.h
@@ -28,6 +28,7 @@
 #include "../../../uds/read_data_by_identifier/include/ReadDataByIdentifier.h"
 #include "../../../utils/include/CreateInterface.h"
 #include "../../../utils/include/GenerateFrames.h"
+#include "../../../mcu/include/MCULogger.h"
 
 #define REQUEST_UPDATE_STATUS_REQUEST_SIZE      0x02
 #define REQUEST_UPDATE_STATUS_RESPONSE_SUCCESS_SIZE	    0x03
@@ -43,8 +44,14 @@
 #define READ_DATA_BY_IDENTIFIER_SID 0x34
 #define READ_DATA_BY_IDENTIFIER_SID_SUCCESS 0x74
 
+#define WRITE_DATA_BY_IDENTIFIER_SID 0x2A
+
 #define PCI_L 0x03
 #define NEGATIVE_RESPONSE 0x7F
+#define REQUEST_OUT_OF_RANGE 0x31
+
+#define MCU_ID 0x10
+#define API_ID 0xFA
 
 /**
  * @brief Macro used for setting byte number i from n to byte b.
@@ -85,11 +92,9 @@ typedef enum OtaUpdateStatesEnum
 class RequestUpdateStatus
 {
 private:        
-	Logger _logger;
     CreateInterface* create_interface;
 public:
-	RequestUpdateStatus(Logger logger);
-	~RequestUpdateStatus();
+	RequestUpdateStatus();
 	/**
 	 * @brief Service method. Receive a request for reading Ota Update Status.
 	 * 	Sends a ReadDataByIdentifier request to MCU, with the Ota Update Status Data Identifier.
@@ -99,7 +104,18 @@ public:
 	 * @param[i] frame_id 
 	 * @param[i] frame_data 
 	 */
-	void requestUpdateStatus(canid_t frame_id, std::vector<uint8_t> frame_data);
+	std::vector<uint8_t> requestUpdateStatus(canid_t frame_id, std::vector<uint8_t> frame_data);
+
+	/**
+	 * @brief Method used for checking if a 8 bit number represents a valid OTA status.
+	 * 
+	 * @param[i] status 
+	 * @return true 
+	 * @return false 
+	 */
+	bool isValidStatus(uint8_t status);
+
+	~RequestUpdateStatus();
 };
 
 #endif /* REQUEST_UPDATE_STATUS_H */

--- a/src/ota/request_update_status/include/RequestUpdateStatus.h
+++ b/src/ota/request_update_status/include/RequestUpdateStatus.h
@@ -94,7 +94,6 @@ private:
 public:
 	int socket = -1;
 	RequestUpdateStatus(int socket);
-	~RequestUpdateStatus();
 	/**
 	 * @brief Service method. Receive a request for reading Ota Update Status.
 	 * 	Sends a ReadDataByIdentifier request to MCU, with the Ota Update Status Data Identifier.

--- a/src/ota/request_update_status/src/RequestUpdateStatus.cpp
+++ b/src/ota/request_update_status/src/RequestUpdateStatus.cpp
@@ -11,13 +11,13 @@
 
 #include "../include/RequestUpdateStatus.h"
 
-RequestUpdateStatus::RequestUpdateStatus(Logger logger) : _logger{logger}
+RequestUpdateStatus::RequestUpdateStatus()
 {
     /* Interface needed for sending the response. */
-    create_interface = create_interface->getInstance(0x00, _logger);
+    create_interface = create_interface->getInstance(0x00, MCULogger);
 }
 
-void RequestUpdateStatus::requestUpdateStatus(canid_t request_id, std::vector<uint8_t> request)
+std::vector<uint8_t> RequestUpdateStatus::requestUpdateStatus(canid_t request_id, std::vector<uint8_t> request)
 {
     /* Request validation similar to ReadDataByIdentifier, no need for making the same checks. */
 
@@ -26,6 +26,12 @@ void RequestUpdateStatus::requestUpdateStatus(canid_t request_id, std::vector<ui
     uint8_t receiver_byte = GET_BYTE(response_id, 0);   /* Get the first byte - receiver */
     uint8_t sender_byte = GET_BYTE(response_id, 1);     /* Get second byte - sender */
 
+    if(receiver_byte != MCU_ID || sender_byte != API_ID)
+    {
+        LOG_WARN(MCULogger.GET_LOGGER(), "Request update status must be made from API to MCU. Request redirected from API to MCU.");
+        receiver_byte = MCU_ID;
+        sender_byte = API_ID;
+    }
     SET_BYTE(response_id, 0, sender_byte);              /* Replace sender with receiver */
     SET_BYTE(response_id, 1, receiver_byte);            /* Replace receiver with sender */
 
@@ -39,7 +45,7 @@ void RequestUpdateStatus::requestUpdateStatus(canid_t request_id, std::vector<ui
     SET_BYTE(request_id, 1, 0x00); /* Set sender to 0x00, this will tell the readData service to not send a frame, but return the response */
 
     ReadDataByIdentifier RIDB;
-    std::vector<uint8_t> RIDB_response = RIDB.readDataByIdentifier(request_id, readDataRequest, _logger);
+    std::vector<uint8_t> RIDB_response = RIDB.readDataByIdentifier(request_id, readDataRequest, MCULogger);
     std::vector<uint8_t> response;
 
     /* If a negative response is sent from readDataByIdentifier service, send the same response from requestUpdateStatus, but with changed SID. */
@@ -51,17 +57,44 @@ void RequestUpdateStatus::requestUpdateStatus(canid_t request_id, std::vector<ui
         response.push_back(RIDB_response[3]);           /* Negative response code */
     }
     else
-    {   
-        /* Everything ok, Ota Update Status received*/
-        response.push_back(PCI_L);                              /* PCI_l */
-        response.push_back(REQUEST_UPDATE_STATUS_SID_SUCCESS);  /* SERVICE SUCCESs = SID + 0X40 */
-        response.push_back(RIDB_response[0]);                   /* OTA UPDATE STATUS */
+    {   /* Check if the received status value is a valid one */
+        uint8_t status = RIDB_response[0];
+        if (isValidStatus(RIDB_response[0]) == 0)
+        {
+            LOG_WARN(MCULogger.GET_LOGGER(), "Status value {} read from readDataByIdentifier is invalid.", status);
+            response.push_back(PCI_L);           /* PCI_l*/
+            response.push_back(NEGATIVE_RESPONSE);           /* Negative response */
+            response.push_back(REQUEST_UPDATE_STATUS_SID);  /* SID */
+            response.push_back(REQUEST_OUT_OF_RANGE);           /* Negative response code */
+        }
+        else
+        {
+            /* Everything ok, Ota Update Status received*/
+            response.push_back(PCI_L);                              /* PCI_l */
+            response.push_back(REQUEST_UPDATE_STATUS_SID_SUCCESS);  /* SERVICE SUCCESs = SID + 0X40 */
+            response.push_back(status);                   /* OTA UPDATE STATUS */
+        }
     }
 
-    GenerateFrames generate_frames(create_interface->getSocketApiWrite(), _logger);
+    GenerateFrames generate_frames(create_interface->getSocketApiWrite(), MCULogger);
     generate_frames.sendFrame(response_id, response);
+    
+    return response;
 }
 
+bool RequestUpdateStatus::isValidStatus(uint8_t status)
+{
+    std::vector<OtaUpdateStatesEnum> valid_states{IDLE,INIT,READY,PROCESSING,PROCESSING_TRANSFER_COMPLETE,PROCESSING_TRANSFER_FAILED,WAIT,WAIT_DOWNLOAD_COMPLETED,WAIT_DOWNLOAD_FAILED,VERIFY,ACTIVATE,ACTIVATE_INSTALL_COMPLETE,ACTIVATE_INSTALL_FAILED,ERROR};
+
+    for(auto &state : valid_states)
+    {
+        if(status ^ state == 0)
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
 
 RequestUpdateStatus::~RequestUpdateStatus()
 {

--- a/src/utils/include/GenerateFrames.h
+++ b/src/utils/include/GenerateFrames.h
@@ -308,7 +308,7 @@ class GenerateFrames
         /**
          * @brief NOT IMPLEMENTED!!
          */
-        bool requestUpdateStatus(int id, bool response=false);
+        bool requestUpdateStatusResponse(int id, std::vector<uint8_t> response);
     private:
         /**
          * @brief Set the socket parameter

--- a/src/utils/src/GenerateFrames.cpp
+++ b/src/utils/src/GenerateFrames.cpp
@@ -601,10 +601,14 @@ void GenerateFrames::requestTransferExit(int id, bool response)
     return;
 }
 
-bool GenerateFrames::requestUpdateStatus(int id, bool response)
+bool GenerateFrames::requestUpdateStatusResponse(int id, std::vector<uint8_t> response)
 {
-    /* No impplementation, I don't find this service in the standart */
-    return false;
+    this->sendFrame(id, response);
+    if(response[1] == 0x7F)
+    {
+        return false;
+    }
+    return true;
 }
 
 /* Private */


### PR DESCRIPTION
- Initialised OTA status to IDLE at the startup of the MCU using WriteDataByIdentifier
- Integrated with ReadDataByIdentifier service.
- Added validation for status value
- Added a check to warn the user if this service is not requested from API to MCU and automatically redirect to this.
- Changed the service return from void to vector<uint8> => the response value can be accessed directly from another service.
- Removed logger from service class (default logger used will be MCU logger because only MCU can request this service)