### PR TITLE
Create style-checker on a new branch

### DIFF
--- a/.github/workflows/style-checker.yml
+++ b/.github/workflows/style-checker.yml
@@ -1,0 +1,16 @@
+name: Google C++ Style Checker
+on:
+  pull_request:
+    branches: [feature/UDS, feature/OTA]
+    paths: ['**.c', '**.cpp', '**.h', '**.hpp', '**.cxx', '**.hxx', '**.cc', '**.hh', '**CMakeLists.txt', 'meson.build', '**.cmake']
+  push:
+    branches: [feature/UDS, feature/OTA]
+    paths: ['**.c', '**.cpp', '**.h', '**.hpp', '**.cxx', '**.hxx', '**.cc', '**.hh', '**CMakeLists.txt', 'meson.build', '**.cmake']
+jobs:
+  style-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Run Google C++ Style Analysis
+        uses: naivesystems/googlecpp-action@2023.3.3.0


### PR DESCRIPTION
The .github/workflows directory in your repository is searched for workflow files at the associated commit SHA or Git ref. The workflow files must be present in that commit SHA or Git ref to be considered.

For example, if the event occurred on a particular repository branch, then the workflow files must be present in the repository on that branch.

Thus I want to try to put this new script on DEV_BE