### PR TITLE
Feature/uds security access Improve 2 + bugs Solved

### DIFF
--- a/src/uds/authentication/include/SecurityAccess.h
+++ b/src/uds/authentication/include/SecurityAccess.h
@@ -28,55 +28,92 @@ class SecurityAccess
     public:
     /* SID for SecurityAccess */
     static const uint8_t SECURITY_ACCESS_SID = 0x27;
-
     /* SubFunctionNotSupported */
     static const uint8_t SFNS = 0x12;
-
     /* IncorrectMesssageLengthOrInvalidFormat */
     static const uint8_t IMLOIF = 0x13;
-
     /* RequestSequenceError */
     static const uint8_t RSE = 0x24;
-
     /* Invalid key */
     static const uint8_t IK = 0x35;
-
     /* Exceeded nr of attempts */
     static const uint8_t ENOA = 0x36;
-
     /* Required time delay not expired */
     static const uint8_t RTDNE = 0x37;
-
     /**
      * Adjust it here.
     */
     static const uint8_t TIMEOUT_IN_SECONDS = 5;
 
-    /**
-     * @brief Default constructor
-    */
-    SecurityAccess(int socket, Logger& security_logger);
-
-    void securityAccess(canid_t can_id, const std::vector<uint8_t>& data);
-
-    std::vector<uint8_t> computeKey(const std::vector<uint8_t>& seed);
-
-    std::vector<uint8_t> generateRandomBytes(size_t length);
-
-    /**
-     * @brief Getter for MCU state access
-     * @return The current value of MCU state
-    */
-    static bool getMcuState();
+    private:
+        GenerateFrames* generate_frames;
+        Logger& security_logger;
+        int socket = -1;
+        static uint8_t nr_of_attempts;
+        static bool mcu_state;
+        static uint32_t time_left;
+        static std::vector<uint8_t> security_access_seed;
+    
+    public:
+        /**
+         * @brief Constructs a SecurityAccess object with a specified socket and logger.
+         * This constructor initializes the SecurityAccess object using the provided
+         * socket for communication and a reference to a Logger object for logging 
+         * security-related events.
+         *
+         * @param socket The socket descriptor used for communication.
+         * @param security_logger Reference to a Logger object for logging security events.
+        */
+        SecurityAccess(int socket, Logger& security_logger);
+        /**
+         * @brief Main method to the 0x27 Security Access UDS service.
+         * Processes security access using the specified CAN ID and data.
+         *
+         * @param can_id The CAN identifier used for the security access operation.
+         * @param data A vector containing the data bytes to be processed.
+         * @return void
+        */
+        void securityAccess(canid_t can_id, const std::vector<uint8_t>& data);
+        /**
+         * @brief Getter for MCU state access.
+         * 
+         * @return The current value of MCU state(true or false).
+        */
+        static bool getMcuState();
 
     private:
-    GenerateFrames* generate_frames;
-    Logger& security_logger;
-    int socket = -1;
-    static uint8_t nr_of_attempts;
-    static bool mcu_state;
-    static int time_left;
-    static std::vector<uint8_t> security_access_seed;
+        /**
+         * @brief Computes a security key based on the provided seed using bitwise operations.
+         * This function generates a security key from the given seed vector by computing 
+         * the two's complement of each byte in the seed. The two's complement is obtained 
+         * by inverting the bits of each byte and adding one.
+         *
+         * @param seed A vector of bytes representing the seed from which the key is computed.
+         * @return A vector of bytes representing the computed security key.
+        */
+        std::vector<uint8_t> computeKey(const std::vector<uint8_t>& seed);
+        /**
+         * @brief Generates a vector of random bytes representing the seed.
+         * This method creates a vector of the specified length filled with random bytes. 
+         * It uses a random number generator with a uniform distribution to ensure each byte 
+         * value is between 0 and 255.
+         * 
+         * @param length The number of random bytes to generate for seed.
+         * @return A vector of random bytes representing the seed.
+         */
+        std::vector<uint8_t> generateRandomBytes(size_t length);
+        /**
+         * @brief Converts a time value in seconds to a CAN frame format.
+         * This method constructs a CAN frame consisting of a predefined sequence 
+         * followed by padding bytes (if necessary) and the time value in seconds, 
+         * ensuring the frame is exactly 8 bytes long. The time value is added in 
+         * big-endian format.
+         * 
+         * @param timeInSeconds The time value in seconds to be included in the frame (max 4 bytes).
+         * @return A vector of bytes representing the CAN frame.
+        */
+        std::vector<uint8_t> convertTimeToCANFrame(uint32_t timeInSeconds);
+
 };
 
 #endif

--- a/src/uds/authentication/include/SecurityAccess.h
+++ b/src/uds/authentication/include/SecurityAccess.h
@@ -15,6 +15,7 @@
 #include <bitset>
 #include <iomanip>
 #include <random>
+#include <chrono>
 
 #include "../../../utils/include/GenerateFrames.h"
 #include "../../utils/include/Logger.h"
@@ -47,7 +48,12 @@ class SecurityAccess
     static const uint8_t RTDNE = 0x37;
 
     /**
-    * @brief Default constructor
+     * Adjust it here.
+    */
+    static const uint8_t TIMEOUT_IN_SECONDS = 5;
+
+    /**
+     * @brief Default constructor
     */
     SecurityAccess(int socket, Logger& security_logger);
 
@@ -58,8 +64,8 @@ class SecurityAccess
     std::vector<uint8_t> generateRandomBytes(size_t length);
 
     /**
-    * @brief Getter for MCU state access
-    * @return The current value of MCU state
+     * @brief Getter for MCU state access
+     * @return The current value of MCU state
     */
     static bool getMcuState();
 
@@ -67,7 +73,9 @@ class SecurityAccess
     GenerateFrames* generate_frames;
     Logger& security_logger;
     int socket = -1;
+    static uint8_t nr_of_attempts;
     static bool mcu_state;
+    static int time_left;
     static std::vector<uint8_t> security_access_seed;
 };
 

--- a/src/uds/authentication/include/SecurityAccess.h
+++ b/src/uds/authentication/include/SecurityAccess.h
@@ -27,23 +27,21 @@ class SecurityAccess
 {
     public:
     /* SID for SecurityAccess */
-    static const uint8_t SECURITY_ACCESS_SID = 0x27;
+    static constexpr uint8_t SECURITY_ACCESS_SID = 0x27;
     /* SubFunctionNotSupported */
-    static const uint8_t SFNS = 0x12;
+    static constexpr uint8_t SFNS = 0x12;
     /* IncorrectMesssageLengthOrInvalidFormat */
-    static const uint8_t IMLOIF = 0x13;
+    static constexpr uint8_t IMLOIF = 0x13;
     /* RequestSequenceError */
-    static const uint8_t RSE = 0x24;
+    static constexpr uint8_t RSE = 0x24;
     /* Invalid key */
-    static const uint8_t IK = 0x35;
+    static constexpr uint8_t IK = 0x35;
     /* Exceeded nr of attempts */
-    static const uint8_t ENOA = 0x36;
+    static constexpr uint8_t ENOA = 0x36;
     /* Required time delay not expired */
-    static const uint8_t RTDNE = 0x37;
-    /**
-     * Adjust it here.
-    */
-    static const uint8_t TIMEOUT_IN_SECONDS = 5;
+    static constexpr uint8_t RTDNE = 0x37;
+    /* Adjust delay timer here. */
+    static constexpr uint8_t TIMEOUT_IN_SECONDS = 0x05;
 
     private:
         GenerateFrames* generate_frames;
@@ -113,7 +111,6 @@ class SecurityAccess
          * @return A vector of bytes representing the CAN frame.
         */
         std::vector<uint8_t> convertTimeToCANFrame(uint32_t timeInSeconds);
-
 };
 
 #endif

--- a/src/uds/authentication/src/SecurityAccess.cpp
+++ b/src/uds/authentication/src/SecurityAccess.cpp
@@ -135,8 +135,8 @@ void SecurityAccess::securityAccess(canid_t can_id, const std::vector<uint8_t>& 
                     /* Adjust the seed length between 1 and 5.*/
                     size_t seed_length = 2;
 
-                    /* std::vector<uint8_t> seed = generateRandomBytes(seed_length); */
-                    std::vector<uint8_t> seed = {0x36,0x57};
+                    std::vector<uint8_t> seed = generateRandomBytes(seed_length);
+                    /* std::vector<uint8_t> seed = {0x36,0x57}; */
 
                     /* PCI length = seed_length + 2(0x67 and 0x01)*/
                     response.push_back(2 + seed_length);


### PR DESCRIPTION
Improvements:
1)Added NRC exceededNumberOfAttempts and requiredTimeDelayNotExpired (implemented the cases when those could rise)
2)Added delaytimer in Negative response for requiredTimeDelayNotExpired(in milliseconds, bigendian format---example 5 miliseconds will be 00 00 00 05, we always have 4 bytes and we complete with 0x00 the padding before if necessary)
3)Solved bugs (one when timer was uint8 because i worked in seconds previously and i forgot to change, and another when i need to reset nr of attempts because delay timer expired, endTime must be reseted to a more larger time then now, condition when endTime expires is when now becomes greater than endTime)
4)Comments, documentation
5)Removed InterfaceLog(from previous commit), added more logs, method to convert the remaining time until delay timer expires into bytes with padding before, logs which prints seconds and milliseconds remaining)
6)Now all variables needed for other services are inside the class(static), not in MCU module(i added getter for the state of the server, if it is locked or unlocked).
Service is now operating correctly and completely in my opinion.
Future: after entering a correct key, the unlocked state of the MCU need to expire, probably when  the control unit returns to default session
Tested, but please test yourself :)