### PR TITLE
threading lock for can bus

### DIFF
--- a/src/rest_api/actions/generate_frames.py
+++ b/src/rest_api/actions/generate_frames.py
@@ -1,7 +1,10 @@
 import can
 from utils.logger import SingletonLogger
 from config import Config
+import threading
 
+
+can_lock = threading.Lock()
 
 logger_singleton = SingletonLogger('logger.log')
 logger = logger_singleton.logger
@@ -17,11 +20,12 @@ class GenerateFrame:
             self.bus = bus
 
     def send_frame(self, id, data):
-        message = can.Message(arbitration_id=id, data=data, is_extended_id=True)
-        try:
-            self.bus.send(message)
-        except can.CanError:
-            print("Message not sent")
+        with can_lock:
+            message = can.Message(arbitration_id=id, data=data, is_extended_id=True)
+            try:
+                self.bus.send(message)
+            except can.CanError:
+                print("Message not sent")
 
     def control_frame(self, id):
         data = [0x30, 0x00, 0x00, 0x00]

--- a/src/rest_api/requirements.txt
+++ b/src/rest_api/requirements.txt
@@ -35,4 +35,3 @@ typing-extensions==4.12.2
 werkzeug==3.0.3
 wrapt==1.16.0
 zipp==3.19.2
-

--- a/src/rest_api/utils/scripts/battery_read_info.sh
+++ b/src/rest_api/utils/scripts/battery_read_info.sh
@@ -1,56 +1,56 @@
-cansend vcan0 2FA#025001
+cansend vcan1 2FA#025001
 sleep 1
-cansend vcan0 2FA#0469010102
+cansend vcan1 2FA#0469010102
 sleep 1
-cansend vcan0 2FA#026902
+cansend vcan1 2FA#026902
 sleep 1
 
 # Battery energy level (0-100%)
-cansend vcan0 2FA#0462016401 # Example: 100%
+cansend vcan1 2FA#0462016401 # Example: 100%
 
 sleep 1
 
 # Battery voltage (in tenths of volts, e.g., 1234 = 123.4V)
-cansend vcan0 2FA#046201A00A # Example: 10.0V
+cansend vcan1 2FA#046201A00A # Example: 10.0V
 
 sleep 1
 
 # Battery state of charge (0-100%)
-cansend vcan0 2FA#046201D050 # Example: 80%
+cansend vcan1 2FA#046201D050 # Example: 80%
 
 sleep 1
 
 # Battery temperature (in tenths of degrees Celsius, e.g., 250 = 25.0°C)
-cansend vcan0 2FA#046201E190 # Example: 25.0°C
+cansend vcan1 2FA#046201E190 # Example: 25.0°C
 
 sleep 1
 
 # Battery life cycle (e.g., 500 cycles)
-cansend vcan0 2FA#046201F1F4 # Example: 500 cycles
+cansend vcan1 2FA#046201F1F4 # Example: 500 cycles
 
 sleep 1
 
 # Battery fully charged (1 for true, 0 for false)
-cansend vcan0 2FA#046202A001 # Example: Fully charged
+cansend vcan1 2FA#046202A001 # Example: Fully charged
 
 sleep 1
 
 # ECU Serial number (example value, usually a fixed identifier)
-cansend vcan0 2FA#0462F12F07 # Example: 12345
+cansend vcan1 2FA#0462F12F07 # Example: 12345
 
 sleep 1
 
 # Battery range (in kilometers, e.g., 250km)
-cansend vcan0 2FA#046202B0FA # Example: 250km
+cansend vcan1 2FA#046202B0FA # Example: 250km
 
 sleep 1
 
 # Battery charging time (in minutes, e.g., 120 minutes)
-cansend vcan0 2FA#046202C078 # Example: 120 minutes
+cansend vcan1 2FA#046202C078 # Example: 120 minutes
 
 sleep 1
 
 # Battery consumption (in tenths of kWh, e.g., 150 = 15.0kWh)
-cansend vcan0 2FA#046202D096 # Example: 15.0kWh
+cansend vcan1 2FA#046202D096 # Example: 15.0kWh
 
 sleep 1

--- a/src/rest_api/utils/scripts/battery_read_info2.sh
+++ b/src/rest_api/utils/scripts/battery_read_info2.sh
@@ -1,56 +1,56 @@
-cansend vcan0 2FA#025001
+cansend vcan1 2FA#025001
 sleep 1
-cansend vcan0 2FA#0469010102
+cansend vcan1 2FA#0469010102
 sleep 1
-cansend vcan0 2FA#026902
+cansend vcan1 2FA#026902
 sleep 1
 
 # Battery energy level (75% -> 0x4B)
-cansend vcan0 2FA#0462014B00 # 75%
+cansend vcan1 2FA#0462014B00 # 75%
 
 sleep 1
 
 # Battery voltage (120.0V -> 0x04B0)
-cansend vcan0 2FA#046201A004B0 # 120.0V
+cansend vcan1 2FA#046201A004B0 # 120.0V
 
 sleep 1
 
 # Battery state of charge (70% -> 0x46)
-cansend vcan0 2FA#046201D04600 # 70%
+cansend vcan1 2FA#046201D04600 # 70%
 
 sleep 1
 
 # Battery temperature (30.0°C -> 0x012C)
-cansend vcan0 2FA#046201E0012C # 30.0°C
+cansend vcan1 2FA#046201E0012C # 30.0°C
 
 sleep 1
 
 # Battery life cycle (350 cycles -> 0x015E)
-cansend vcan0 2FA#046201F0015E # 350 cycles
+cansend vcan1 2FA#046201F0015E # 350 cycles
 
 sleep 1
 
 # Battery fully charged (False -> 0x00)
-cansend vcan0 2FA#046202A00000 # Not fully charged
+cansend vcan1 2FA#046202A00000 # Not fully charged
 
 sleep 1
 
 # ECU Serial number (Example: 23456 -> 0x05BA0)
-cansend vcan0 2FA#0462F1005BA0 # Example serial number
+cansend vcan1 2FA#0462F1005BA0 # Example serial number
 
 sleep 1
 
 # Battery range (300km -> 0x012C)
-cansend vcan0 2FA#046202B0012C # 300km
+cansend vcan1 2FA#046202B0012C # 300km
 
 sleep 1
 
 # Battery charging time (90 minutes -> 0x005A)
-cansend vcan0 2FA#046202C0005A # 90 minutes
+cansend vcan1 2FA#046202C0005A # 90 minutes
 
 sleep 1
 
 # Battery consumption (18.0kWh -> 0x00B4)
-cansend vcan0 2FA#046202D000B4 # 18.0kWh
+cansend vcan1 2FA#046202D000B4 # 18.0kWh
 
 sleep 1

--- a/src/rest_api/utils/scripts/engine_read_info.sh
+++ b/src/rest_api/utils/scripts/engine_read_info.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 
 # Send CAN frames for reading engine information
-cansend vcan0 023#0462101024
+cansend vcan1 023#0462101024
 sleep 1
-cansend vcan0 023#025003
+cansend vcan1 023#025003
 sleep 1
-cansend vcan0 023#0141
+cansend vcan1 023#0141
 sleep 1
-cansend vcan0 023#0142
+cansend vcan1 023#0142
 sleep 1
-cansend vcan0 023#0143
+cansend vcan1 023#0143
 sleep 1
-cansend vcan0 023#0144
+cansend vcan1 023#0144
 sleep 1
-cansend vcan0 023#0145
+cansend vcan1 023#0145
 sleep 1
-cansend vcan0 023#0146
+cansend vcan1 023#0146
 sleep 1
-cansend vcan0 023#0147
+cansend vcan1 023#0147
 sleep 1
-cansend vcan0 023#0148
+cansend vcan1 023#0148
 sleep 1
-cansend vcan0 023#0149
+cansend vcan1 023#0149
 sleep 1

--- a/src/rest_api/utils/scripts/req_ids.sh
+++ b/src/rest_api/utils/scripts/req_ids.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cansend vcan0 0FA#0299334455667788
+cansend vcan1 0FA#0299334455667788
 # cansend vcan0 123#8D029901020304
 # sleep 1
 # cansend vcan0 123#8D02990102030405


### PR DESCRIPTION
din libraria threading, functia Lock() previne accesarea simultana a can bus-ului de catre mai multe threaduri