### PR TITLE
Feature/ota project path finding fix

### DIFF
--- a/src/autoscripts/ReleaseScript.py
+++ b/src/autoscripts/ReleaseScript.py
@@ -23,8 +23,9 @@ import shutil
 PROJECT_PATH = os.path.abspath(os.path.join(os.getcwd(), "..", ".."))
 PATH_SOFTWARE_RELEASES = PROJECT_PATH + '/software_releases'
 
+
 def create_exec(version: str, sw_to_build: str):
-    dir_name = "release_" + sw_to_build + '_'  + version
+    dir_name = "release_" + sw_to_build + '_' + version
     directory_path = os.path.expanduser(PATH_SOFTWARE_RELEASES + "/"+dir_name)
 
     if subprocess.run(["ls {0}/{1} 2>/dev/null".format(PATH_SOFTWARE_RELEASES, dir_name)], shell=True).returncode == 0:
@@ -76,6 +77,7 @@ def uploadRelease(directory_path: str):
                               DRIVE_ECU_BATTERY_SW_VERSIONS_FILE)
             print(file + ' UPLOADED TO GOOGLE DRIVE')
 
+
 def validateSoftwareVersion(software_version):
     if "." not in software_version:
         print("Version not valid, must look like 1.1, 1.6 etc")
@@ -90,9 +92,11 @@ def validateSoftwareVersion(software_version):
         exit(-1)
     return software_version
 
+
 def validateSoftwareToBuild(software_to_build):
-    #TODO
+    # TODO
     return software_to_build
+
 
 def main():
     version = "1.0"
@@ -107,6 +111,7 @@ def main():
 
     output_path = create_exec(version, sw_to_build)
     uploadRelease(output_path)
+
 
 if __name__ == "__main__":
     main()

--- a/src/autoscripts/ReleaseScript.py
+++ b/src/autoscripts/ReleaseScript.py
@@ -8,63 +8,62 @@ import shutil
 # example: python3 ReleaseScript.py 1 all
 
 PROJECT_PATH = os.path.abspath(os.path.join(os.getcwd(), "..", ".."))
-path_tool = ""
-
+PATH_SOFTWARE_RELEASES = PROJECT_PATH + '/software_releases'
 
 def find_path():
     # Search in most impotrtantdir
-    possible_paths = ["~/PoC/tools", "~/Desktop/PoC/tools"]
+    possible_paths = ["~/PoC/software_releases", "~/Desktop/PoC/software_releases"]
     for path in possible_paths:
         if os.system("cd {0} 2>/dev/null".format(path)) == 0:
             global path_tool
-            path_tool = path
+            PATH_SOFTWARE_RELEASES = path
             return
     # Search in the whole user dir
     result = subprocess.run("find ~ -type d -name PoC 2>/dev/null",
                             shell=True, stdout=subprocess.PIPE, text=True)
     if str(result.stdout) != "":
-        path_tool = str(result.stdout)[:-1]+"/tools"
+        PATH_SOFTWARE_RELEASES = str(result.stdout)[:-1]+"/software_releases"
         return
     # Unable to find
-    print("Unable to find the PoC/tool dir, please pass the path as second argument")
+    print("Unable to find the PoC/software_releases dir, please pass the path as second argument")
     exit(-1)
 
 
 def checking():
     r = subprocess.run('pwd', shell=True, stdout=subprocess.PIPE, text=True)
     current_dir = str(r.stdout)[-10:-1]
-    if current_dir != "PoC/tools":
+    if current_dir != "PoC/software_releases":
         find_path()
 
 
 def create_exec(version: str, sw_to_build: str):
     dir_name = "release_" + version + '_' + sw_to_build
-    directory_path = os.path.expanduser(path_tool + "/"+dir_name)
+    directory_path = os.path.expanduser(PATH_SOFTWARE_RELEASES + "/"+dir_name)
 
-    if subprocess.run(["ls {0}/{1} 2>/dev/null".format(path_tool, dir_name)], shell=True).returncode == 0:
-        print("This release v{0} alrready exists".format(version))
+    if subprocess.run(["ls {0}/{1} 2>/dev/null".format(PATH_SOFTWARE_RELEASES, dir_name)], shell=True).returncode == 0:
+        print("This release_{0}_{1} already exists".format(version, sw_to_build))
         exit(-1)
     try:
         # Create the directory
         subprocess.run(
-            ["mkdir", "-p", "{0}/{1}".format(path_tool, dir_name)], check=True)
+            ["mkdir", "-p", "{0}/{1}".format(PATH_SOFTWARE_RELEASES, dir_name)], check=True)
         if sw_to_build == "mcu" or sw_to_build == "all":
             # Build the MCU executable
             subprocess.run(
-                ["make", "-C", "{0}/../src/mcu/".format(path_tool)], check=True)
-            mcu_executable_path = "{0}/../src/mcu/main".format(path_tool)
+                ["make", "-C", "{0}/../src/mcu/".format(PATH_SOFTWARE_RELEASES)], check=True)
+            mcu_executable_path = "{0}/../src/mcu/main".format(PATH_SOFTWARE_RELEASES)
             mcu_archive_name = "{0}/{1}/MCU_SW_VERSION_{2}".format(
-                path_tool, dir_name, version)
+                PATH_SOFTWARE_RELEASES, dir_name, version)
             shutil.make_archive(mcu_archive_name, 'zip', root_dir=os.path.dirname(
                 mcu_executable_path), base_dir=os.path.basename(mcu_executable_path))
         if sw_to_build == "ecu" or sw_to_build == "all":
             # Build the Battery Module executable
             subprocess.run(
-                ["make", "-C", "{0}/../src/ecu_simulation/BatteryModule".format(path_tool)], check=True)
+                ["make", "-C", "{0}/../src/ecu_simulation/BatteryModule".format(PATH_SOFTWARE_RELEASES)], check=True)
             battery_executable_path = "{0}/../src/ecu_simulation/BatteryModule/main".format(
-                path_tool)
+                PATH_SOFTWARE_RELEASES)
             battery_archive_name = "{0}/{1}/ECU_BATTERY_SW_VERSION_{2}".format(
-                path_tool, dir_name, version)
+                PATH_SOFTWARE_RELEASES, dir_name, version)
             shutil.make_archive(battery_archive_name, 'zip', root_dir=os.path.dirname(
                 battery_executable_path), base_dir=os.path.basename(battery_executable_path))
 
@@ -84,20 +83,17 @@ def uploadRelease(directory_path: str):
         if "MCU" in file:
             gDrive.uploadFile(file, os.path.join(
                 directory_path, file), DRIVE_MCU_SW_VERSIONS_FILE)
+            print('${file} UPLOADED TO GOOGLE DRIVE')
         elif "BATTERY" in file:
             gDrive.uploadFile(file, os.path.join(directory_path, file),
                               DRIVE_ECU_BATTERY_SW_VERSIONS_FILE)
-
-    print("\n--------- SW Versions Uploaded ----------")
-
+            print('${file} UPLOADED TO GOOGLE DRIVE')
 
 def main():
-    global path_tool
     version = "1"
     sw_to_build = "all"
     if len(sys.argv) > 1:
         version = sys.argv[1]
-        checking()
     elif len(sys.argv) <= 1:
         print("Please provide as argument the version of the release")
         # exit(-1)

--- a/src/autoscripts/ReleaseScript.py
+++ b/src/autoscripts/ReleaseScript.py
@@ -7,6 +7,7 @@ import shutil
 # command: python3 ReleaseScript.py [version_number] [what_to_create: mcu/ecu/all]
 # example: python3 ReleaseScript.py 1 all
 
+PROJECT_PATH = os.path.abspath(os.path.join(os.getcwd(), "..", ".."))
 path_tool = ""
 
 
@@ -75,7 +76,8 @@ def create_exec(version: str, sw_to_build: str):
 
 
 def uploadRelease(directory_path: str):
-    sys.path.append('/home/projectx/accademyprojects/PoC/src/ota/google_drive_api')
+    google_drive_api_path = PROJECT_PATH + '/src/ota/google_drive_api'
+    sys.path.append(google_drive_api_path)
     from GoogleDriveApi import gDrive, DRIVE_MCU_SW_VERSIONS_FILE, DRIVE_ECU_BATTERY_SW_VERSIONS_FILE
 
     for file in os.listdir(directory_path):
@@ -102,7 +104,7 @@ def main():
     if len(sys.argv) > 2:
         sw_to_build = sys.argv[2]
     output_path = create_exec(version, sw_to_build)
-    uploadRelease(output_path)
+    # uploadRelease(output_path)
 
 
 if __name__ == "__main__":

--- a/src/autoscripts/ReleaseScript.py
+++ b/src/autoscripts/ReleaseScript.py
@@ -77,7 +77,17 @@ def uploadRelease(directory_path: str):
             print(file + ' UPLOADED TO GOOGLE DRIVE')
 
 def validateSoftwareVersion(software_version):
-    #TODO
+    if "." not in software_version:
+        print("Version not valid, must look like 1.1, 1.6 etc")
+        exit(-1)
+
+    major_version, minor_version = software_version.split('.')
+    major_version = int(major_version)
+    minor_version = int(minor_version)
+
+    if major_version < 1 or major_version > 8 or minor_version < 0 or minor_version > 15:
+        print("Version not valid. Valid versions are between 1.0 and 8.15")
+        exit(-1)
     return software_version
 
 def validateSoftwareToBuild(software_to_build):

--- a/src/autoscripts/ReleaseScript.py
+++ b/src/autoscripts/ReleaseScript.py
@@ -3,41 +3,28 @@ import sys
 import subprocess
 import shutil
 
-# HOW TO USE THE SCRIPT
-# command: python3 ReleaseScript.py [version_number] [what_to_create: mcu/ecu/all]
-# example: python3 ReleaseScript.py 1 all
+"""
+    STEPS TO DO BEFORE RUNNING THE SCRIPT
+
+1.Create and activate the venv, install dependencies
+    cd /src/rest_api
+    python3.8 -m venv venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+2.Add key.json to PoC folder
+  Copy the key.json from drive PoC folder
+
+    HOW TO USE THE SCRIPT
+
+    command: python3 ReleaseScript.py [version_number] [what_to_create: mcu/ecu/all]
+    example: python3 ReleaseScript.py 1 all
+"""
 
 PROJECT_PATH = os.path.abspath(os.path.join(os.getcwd(), "..", ".."))
 PATH_SOFTWARE_RELEASES = PROJECT_PATH + '/software_releases'
 
-def find_path():
-    # Search in most impotrtantdir
-    possible_paths = ["~/PoC/software_releases", "~/Desktop/PoC/software_releases"]
-    for path in possible_paths:
-        if os.system("cd {0} 2>/dev/null".format(path)) == 0:
-            global path_tool
-            PATH_SOFTWARE_RELEASES = path
-            return
-    # Search in the whole user dir
-    result = subprocess.run("find ~ -type d -name PoC 2>/dev/null",
-                            shell=True, stdout=subprocess.PIPE, text=True)
-    if str(result.stdout) != "":
-        PATH_SOFTWARE_RELEASES = str(result.stdout)[:-1]+"/software_releases"
-        return
-    # Unable to find
-    print("Unable to find the PoC/software_releases dir, please pass the path as second argument")
-    exit(-1)
-
-
-def checking():
-    r = subprocess.run('pwd', shell=True, stdout=subprocess.PIPE, text=True)
-    current_dir = str(r.stdout)[-10:-1]
-    if current_dir != "PoC/software_releases":
-        find_path()
-
-
 def create_exec(version: str, sw_to_build: str):
-    dir_name = "release_" + version + '_' + sw_to_build
+    dir_name = "release_" + sw_to_build + '_'  + version
     directory_path = os.path.expanduser(PATH_SOFTWARE_RELEASES + "/"+dir_name)
 
     if subprocess.run(["ls {0}/{1} 2>/dev/null".format(PATH_SOFTWARE_RELEASES, dir_name)], shell=True).returncode == 0:
@@ -83,25 +70,33 @@ def uploadRelease(directory_path: str):
         if "MCU" in file:
             gDrive.uploadFile(file, os.path.join(
                 directory_path, file), DRIVE_MCU_SW_VERSIONS_FILE)
-            print('${file} UPLOADED TO GOOGLE DRIVE')
+            print(file + ' UPLOADED TO GOOGLE DRIVE')
         elif "BATTERY" in file:
             gDrive.uploadFile(file, os.path.join(directory_path, file),
                               DRIVE_ECU_BATTERY_SW_VERSIONS_FILE)
-            print('${file} UPLOADED TO GOOGLE DRIVE')
+            print(file + ' UPLOADED TO GOOGLE DRIVE')
+
+def validateSoftwareVersion(software_version):
+    #TODO
+    return software_version
+
+def validateSoftwareToBuild(software_to_build):
+    #TODO
+    return software_to_build
 
 def main():
-    version = "1"
+    version = "1.0"
     sw_to_build = "all"
-    if len(sys.argv) > 1:
-        version = sys.argv[1]
-    elif len(sys.argv) <= 1:
-        print("Please provide as argument the version of the release")
-        # exit(-1)
-    if len(sys.argv) > 2:
-        sw_to_build = sys.argv[2]
-    output_path = create_exec(version, sw_to_build)
-    # uploadRelease(output_path)
 
+    if len(sys.argv) < 2:
+        print("Please provide as first argument the version of the release using format 1.0 -> 1.15 and as second argument the software to build mcu/ecu/all")
+        exit(-1)
+    else:
+        version = validateSoftwareVersion(sys.argv[1])
+        sw_to_build = validateSoftwareToBuild(sys.argv[2])
+
+    output_path = create_exec(version, sw_to_build)
+    uploadRelease(output_path)
 
 if __name__ == "__main__":
     main()

--- a/src/ecu_simulation/BatteryModule/Makefile
+++ b/src/ecu_simulation/BatteryModule/Makefile
@@ -1,12 +1,14 @@
 ######### Makefile for BatteryModule
 ######### Author: Theodor Stoica (contact theodor.stoica@randstaddigital.com for any help)
 
+#POC Project root path
+PROJECT_PATH := $(shell cd $(shell pwd)/../../ && pwd)
 #Python flags
 PYTHON_INCL_DIR=-I/usr/include/python3.8
 PYTHON_LDFLAGS = -L/usr/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -lcrypt -ldl -lutil -lm -lpthread
 # Compiler flags
 CXX = g++
-CFLAGS = -std=c++17 -g -Wall -Werror -pthread -I./include -I../../utils/include ${PYTHON_INCL_DIR}
+CFLAGS = -std=c++17 -g -Wall -Werror -pthread -I./include -I../../utils/include ${PYTHON_INCL_DIR} -DPROJECT_PATH=\"$(PROJECT_PATH)\"
 LDFLAGS = -lspdlog -lfmt  ${PYTHON_LDFLAGS}
 
 # Test flags

--- a/src/mcu/Makefile
+++ b/src/mcu/Makefile
@@ -1,13 +1,15 @@
 ######### Makefile for MCU module
 ######### Author: Theodor Stoica (contact theodor.stoica@randstaddigital.com for any help)
 
+#POC Project root path
+PROJECT_PATH := $(shell cd $(shell pwd)/../../ && pwd)
 #Python flags needed for pybing library
 PYTHON_INCL_DIR=-I/usr/include/python3.8
 PYTHON_LDFLAGS = -L/usr/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -lcrypt -ldl -lutil -lm -lpthread
 
 # Compiler flags
 CXX = g++
-CFLAGS = -std=c++17 -g -Wall -Werror -pthread -I./include -I../utils/include ${PYTHON_INCL_DIR}
+CFLAGS = -std=c++17 -g -Wall -Werror -pthread -I./include -I../utils/include ${PYTHON_INCL_DIR} -DPROJECT_PATH=\"$(PROJECT_PATH)\"
 LDFLAGS = -lspdlog -lfmt ${PYTHON_LDFLAGS}
 
 # Test flags

--- a/src/ota/google_drive_api/GoogleDriveApi.py
+++ b/src/ota/google_drive_api/GoogleDriveApi.py
@@ -1,5 +1,6 @@
 import io
 import json
+import os
 
 from googleapiclient.discovery import build
 from google.oauth2 import service_account
@@ -7,7 +8,8 @@ from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseDownload
 from googleapiclient.http import MediaFileUpload
 
-CREDS_PATH = '/home/projectx/accademyprojects/PoC/key.json'
+PROJECT_PATH = os.path.abspath(os.path.join(os.getcwd(), "..", ".."))
+CREDS_PATH = PROJECT_PATH + '/key.json'
 OAUTH2_SCOPE = 'https://www.googleapis.com/auth/drive'
 DRIVE_BASE_FILE = {
     "name": "SW_VERSIONS",

--- a/src/ota/google_drive_api/GoogleDriveApi.py
+++ b/src/ota/google_drive_api/GoogleDriveApi.py
@@ -17,7 +17,7 @@ DRIVE_BASE_FILE = {
 }
 DRIVE_ECU_BATTERY_SW_VERSIONS_FILE = '1QkgBWPEaKg5bnOU0eXjPOEcz6lqNCG-N'
 DRIVE_MCU_SW_VERSIONS_FILE = '1aGo68MWCYBxMVSPd0-jZ4cBGICGdMRxp'
-#TO BE CHANGED WITH THE DESIRED PATH FOR DOWNLOADS
+# TO BE CHANGED WITH THE DESIRED PATH FOR DOWNLOADS
 DRIVE_DOWNLOAD_PATH = PROJECT_PATH
 
 # QUERY STRINGS for google drive api filest.list() method
@@ -27,7 +27,8 @@ FILE_MIMETYPE_QUERY = "mimeType = 'application/vnd.google-apps.file'"
 ecu_map = {
     0x10: "mcu",
     0x11: "battery"
-}   
+}
+
 
 class GDriveAPI:
     # credentials needed for authorization. Created from the google cloud key.json file
@@ -73,7 +74,8 @@ class GDriveAPI:
 
         media = MediaFileUpload(file_path, mimetype='text/plain')
 
-        self.__drive_service.files().create(body=file_metadata, media_body=media, fields='id').execute()
+        self.__drive_service.files().create(
+            body=file_metadata, media_body=media, fields='id').execute()
 
     def downloadFile(self, ecu_id, sw_version_byte, path_to_download=DRIVE_DOWNLOAD_PATH):
         try:
@@ -83,7 +85,8 @@ class GDriveAPI:
             file_to_download = [
                 data for data in self.__drive_data_array if data['type'] == ecu_map[ecu_id] and data['sw_version'] == str(sw_version)]
             if not file_to_download:
-                print(f"No file found with type:{ecu_map[ecu_id]} and version {sw_version}")
+                print(
+                    f"No file found with type:{ecu_map[ecu_id]} and version {sw_version}")
                 return
             print('Version found, downloading..')
             file_to_download = file_to_download[0]  # Access the first element
@@ -110,11 +113,11 @@ class GDriveAPI:
     def __convertByteToSwVersion(self, software_version_byte):
         # Convert the hex string to an integer
         int_value = int(str(software_version_byte), 16)
-        
+
         # SMost significant 3 bits => major version, next 4 bits minor_version, lsb not important for versioning
         major_version = ((int_value & 0b11100000) >> 5) + 1
         minor_version = (int_value & 0b00011110) >> 1
-        
+
         # Combine the parts into the version string
         software_version = f"{major_version}.{minor_version}"
         return software_version
@@ -135,7 +138,7 @@ class GDriveAPI:
         version_with_zip = file_name.split('_')[-1]
         version = version_with_zip.rstrip('.zip')
         return version
-    
+
     def __getDriveData(self, file=DRIVE_BASE_FILE):
 
         folder_data = self.__getFilesFromFolder(file["id"])
@@ -145,7 +148,7 @@ class GDriveAPI:
             'type': self.__getFileType(file),
             'children': [],
         }
-        if(json_file['type'] != "folder"):
+        if (json_file['type'] != "folder"):
             json_file['sw_version'] = self.__getSoftwareVersion(file['name'])
             json_file['size'] = file.get('size', 'N/A')
         self.__drive_data_array.append(json_file)

--- a/src/ota/google_drive_api/GoogleDriveApi.py
+++ b/src/ota/google_drive_api/GoogleDriveApi.py
@@ -120,7 +120,7 @@ class GDriveAPI:
         return software_version
 
     def __getFilesFromFolder(self, folder_name):
-        return self.__drive_service.files().list(q="'" + folder_name + "' in parents", pageSize=10, fields="nextPageToken, files(id, name)").execute()
+        return self.__drive_service.files().list(q="'" + folder_name + "' in parents", pageSize=10, fields="nextPageToken, files(id, name, size)").execute()
 
     def __getFileType(self, file):
         type = "folder"
@@ -147,6 +147,7 @@ class GDriveAPI:
         }
         if(json_file['type'] != "folder"):
             json_file['sw_version'] = self.__getSoftwareVersion(file['name'])
+            json_file['size'] = file.get('size', 'N/A')
         self.__drive_data_array.append(json_file)
         if json_file['type'] == "folder":
             json_file['children'].extend(self.__getDriveData(file)

--- a/src/ota/google_drive_api/GoogleDriveApi.py
+++ b/src/ota/google_drive_api/GoogleDriveApi.py
@@ -110,12 +110,10 @@ class GDriveAPI:
     def __convertByteToSwVersion(self, software_version_byte):
         # Convert the hex string to an integer
         int_value = int(str(software_version_byte), 16)
-        # Extract the most significant 7 bits
-        version_bits = int_value >> 1  # Shift right by 1 to drop the LSB
         
-        # Split the 7 bits into the most significant 4 bits and the least significant 3 bits
-        major_version = version_bits >> 3
-        minor_version = (version_bits & 0b111)
+        # SMost significant 3 bits => major version, next 4 bits minor_version, lsb not important for versioning
+        major_version = ((int_value & 0b11100000) >> 5) + 1
+        minor_version = (int_value & 0b00011110) >> 1
         
         # Combine the parts into the version string
         software_version = f"{major_version}.{minor_version}"

--- a/src/ota/google_drive_api/GoogleDriveApi.py
+++ b/src/ota/google_drive_api/GoogleDriveApi.py
@@ -114,8 +114,8 @@ class GDriveAPI:
         version_bits = int_value >> 1  # Shift right by 1 to drop the LSB
         
         # Split the 7 bits into the most significant 4 bits and the least significant 3 bits
-        major_version = version_bits >> 3  # Shift right by 3 to get the 4 MSBs
-        minor_version = (version_bits & 0b111) + 1  # Mask to get the 3 LSBs
+        major_version = version_bits >> 3
+        minor_version = (version_bits & 0b111)
         
         # Combine the parts into the version string
         software_version = f"{major_version}.{minor_version}"

--- a/src/ota/request_download/include/RequestDownload.h
+++ b/src/ota/request_download/include/RequestDownload.h
@@ -151,7 +151,7 @@ private:
      * 
      * @param version_file_id 
      */
-    void downloadSoftwareVersion(std::string version_file_id);
+    void downloadSoftwareVersion(uint8_t ecu_id, uint8_t sw_version);
 };
 
 #endif /* REQUEST_DOWNLOAD_SERVICE_H */

--- a/src/ota/request_download/src/RequestDownload.cpp
+++ b/src/ota/request_download/src/RequestDownload.cpp
@@ -117,7 +117,10 @@ void RequestDownloadService::requestDownloadRequest(int id, std::vector<uint8_t>
 
     int max_number_block = calculate_max_number_block(memory_size);
 
-    downloadSoftwareVersion("software_version_id");
+    /* To be changed with actual values, these are used for test. */
+    uint8_t ecu_id = 0x10;
+    uint8_t sw_version_byte = 0x22;
+    downloadSoftwareVersion(ecu_id, sw_version_byte);
 
     if (download_type == 0x88)
     {
@@ -444,7 +447,7 @@ bool RequestDownloadService::isLatestSoftwareVersion()
     return false;
 }
 
-void RequestDownloadService::downloadSoftwareVersion(std::string version_file_id)
+void RequestDownloadService::downloadSoftwareVersion(uint8_t ecu_id, uint8_t sw_version)
 {
     namespace py = pybind11;
     py::scoped_interpreter guard{}; // start the interpreter and keep it alive
@@ -474,7 +477,7 @@ void RequestDownloadService::downloadSoftwareVersion(std::string version_file_id
     */
 
     /* Call the downloadFile method from GoogleDriveApi.py */
-    gGdrive_object.attr("downloadFile")(version_file_id);
+     gGdrive_object.attr("downloadFile")(ecu_id, sw_version);
 }
 /** Use libraries for tar
  * #include <archive.h>

--- a/src/ota/request_download/src/RequestDownload.cpp
+++ b/src/ota/request_download/src/RequestDownload.cpp
@@ -119,7 +119,8 @@ void RequestDownloadService::requestDownloadRequest(int id, std::vector<uint8_t>
 
     /* To be changed with actual values, these are used for test. */
     uint8_t ecu_id = 0x10;
-    uint8_t sw_version_byte = 0x22;
+    /* 0x24 => 0010 010 0* => v2.2, LSB not taken in consideration for versioning */
+    uint8_t sw_version_byte = 0x24;
     downloadSoftwareVersion(ecu_id, sw_version_byte);
 
     if (download_type == 0x88)

--- a/src/ota/request_download/src/RequestDownload.cpp
+++ b/src/ota/request_download/src/RequestDownload.cpp
@@ -449,8 +449,12 @@ void RequestDownloadService::downloadSoftwareVersion(std::string version_file_id
     namespace py = pybind11;
     py::scoped_interpreter guard{}; // start the interpreter and keep it alive
 
+    /* PROJECT_PATH defined in makefile to be the root folder path (POC)*/
+    std::string project_path = PROJECT_PATH;
+    std::string path_to_drive_api = project_path + "/src/ota/google_drive_api";
+
     auto sys = py::module::import("sys");
-    sys.attr("path").attr("append")("/home/projectx/accademyprojects/PoC/src/ota/google_drive_api");
+    sys.attr("path").attr("append")(path_to_drive_api);
 
     /* Get the created Python module */
     py::module python_module = py::module::import("GoogleDriveApi");


### PR DESCRIPTION
## Description

Path to GoogleDriveApi.py, Release script and path to key.json were wrong. 
Added a variable in makefiles that has the path to the project root folder (PoC). It is used as starting point where paths are needed.

EXTRA CHANGES:
1. Release script can create versions between 1.0 and 8.15. Validation added.
2. Data from google drive also includes size now.
3. GoogleDriveApi download needs ecu_id (0x10 or 0x11) and sw_version as parameters.
4. A byte from the request of requestDownloadService is used for choosing the version.
   001 0010 0
  most significant 3 bits are for major version (1-8) 
  next 4 bits are for minor version(updates) (0-15)
  least significant bit is for download type (manual/auto)
5. Download path is PoC folder


## Trello link [here](hotfix - no trello ticket)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
