### PR TITLE
Manual testing frame for more scenarios and updated dictionary

### DIFF
--- a/src/rest_api/actions/manual_send_frame.py
+++ b/src/rest_api/actions/manual_send_frame.py
@@ -66,6 +66,7 @@ def handle_negative_response(frame_response):
         0x12: "SubFunctionNotSupported",
         0x13: "IncorrectMessageLengthOrInvalidFormat",
         0x24: "RequestSequenceError",
+        0x31: "RequestOutofRange",
         0x35: "InvalidKey",
         0x36: "ExceededNumberOfAttempts",
         0x37: "RequiredTimeDelayNotExpired"


### PR DESCRIPTION
## Description

Manual testing for negative responses. I tested all the possible negative responses. Currently The testable negative responses are: RequestOutOfRange, SubfunctionNotSupported and IncorrectMessageLengthOrInvalidFormat. You could see on the trello link attachment a screenshot with negative responses on MCU logs. Also I updated the dictionary from python with a missed negative response from backend functionalities.

## Trello link [here](https://trello.com/c/hBbjBWZv/60-follow-up-negative-responses-scenarios-for-existing-sids)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
![Capture](https://github.com/user-attachments/assets/752f511c-987d-47d1-abbf-2687835f8b61)

