### PR TITLE
Integrate SecurityService into UDS services that need it

### DIFF
--- a/src/ecu_simulation/BatteryModule/Makefile
+++ b/src/ecu_simulation/BatteryModule/Makefile
@@ -229,7 +229,9 @@ OBJS_CLEARDTC_TEST = $(OBJ_DIR)/Logger_test.o \
 OBJS_ROUTINECONTROL_TEST = $(OBJ_DIR)/MemoryManager_test.o \
 						   $(OBJ_DIR)/Logger_test.o \
 			   			   $(OBJ_DIR)/GenerateFrames_test.o \
-			   			   $(OBJ_DIR)/RoutineControl_test.o
+			   			   $(OBJ_DIR)/RoutineControl_test.o \
+			   			   $(OBJ_DIR)/NegativeResponse_test.o \
+			   			   $(OBJ_DIR)/SecurityAccess_test.o
 
 OTA_OBJS_TEST = $(OBJ_DIR)/RequestUpdateStatus_test.o \
 				$(OBJ_DIR)/RequestTransferExit_test.o \
@@ -245,16 +247,16 @@ OBJS_REQUESTTRANSFEREXIT_TEST = $(OBJ_DIR)/Logger_test.o \
 			   			  $(OBJ_DIR)/RequestTransferExit_test.o
 						
 OBJS_REQUESTDOWNLOAD_TEST = $(OBJ_DIR)/Logger_test.o \
-			   			  $(OBJ_DIR)/GenerateFrames_test.o \
-			   			  $(OBJ_DIR)/RequestDownload_test.o
+			   			    $(OBJ_DIR)/GenerateFrames_test.o \
+			   			    $(OBJ_DIR)/RequestDownload_test.o
 
 OBJS_TRANSFERDATA_TEST = $(OBJ_DIR)/Logger_test.o \
 			   			  $(OBJ_DIR)/GenerateFrames_test.o \
 			   			  $(OBJ_DIR)/TransferData_test.o
 
 OBJS_ACCESSTIMINGPARAMETER_TEST = $(OBJ_DIR)/Logger_test.o \
-			   						 $(OBJ_DIR)/GenerateFrames_test.o \
-			   						 $(OBJ_DIR)/AccessTimingParameter_test.o
+			   					  $(OBJ_DIR)/GenerateFrames_test.o \
+			   					  $(OBJ_DIR)/AccessTimingParameter_test.o
 
 OBJS_TEST = $(MCU_OBJS_TEST) \
             $(BATTERY_OBJS_TEST) \

--- a/src/ecu_simulation/BatteryModule/Makefile
+++ b/src/ecu_simulation/BatteryModule/Makefile
@@ -197,7 +197,7 @@ UDS_OBJS_TEST = $(OBJ_DIR)/DiagnosticSessionControl_test.o \
                 $(OBJ_DIR)/WriteDataByIdentifier_test.o \
                 $(OBJ_DIR)/EcuReset_test.o \
                 $(OBJ_DIR)/SecurityAccess_test.o \
-				$(OBJ_DIR)/TesterPresentTest.o \
+				$(OBJ_DIR)/TesterPresent_test.o \
                 $(OBJ_DIR)/ReadDtcInformation_test.o \
                 $(OBJ_DIR)/ClearDtc_test.o \
                 $(OBJ_DIR)/RoutineControl_test.o \

--- a/src/mcu/Makefile
+++ b/src/mcu/Makefile
@@ -178,7 +178,7 @@ UTILS_OBJS_TEST = $(OBJ_DIR)/MemoryManager_test.o \
                   $(OBJ_DIR)/Logger_test.o \
                   $(OBJ_DIR)/CreateInterface_test.o \
                   $(OBJ_DIR)/GenerateFrames_test.o \
-                  $(OBJ_DIR)/NegativeResponse.o
+                  $(OBJ_DIR)/NegativeResponse_test.o
 
 OBJS_GENERATE_TEST = $(OBJ_DIR)/Logger_test.o \
                   	 $(OBJ_DIR)/GenerateFrames_test.o

--- a/src/mcu/Makefile
+++ b/src/mcu/Makefile
@@ -196,7 +196,7 @@ UDS_OBJS_TEST = $(OBJ_DIR)/DiagnosticSessionControl_test.o \
                 $(OBJ_DIR)/WriteDataByIdentifier_test.o \
                 $(OBJ_DIR)/EcuReset_test.o \
                 $(OBJ_DIR)/SecurityAccess_test.o \
-				$(OBJ_DIR)/TesterPresentTest.o \
+				$(OBJ_DIR)/TesterPresent_test.o \
                 $(OBJ_DIR)/ReadDtcInformation_test.o \
                 $(OBJ_DIR)/ClearDtc_test.o \
                 $(OBJ_DIR)/RoutineControl_test.o \

--- a/src/mcu/Makefile
+++ b/src/mcu/Makefile
@@ -228,7 +228,9 @@ OBJS_CLEARDTC_TEST = $(OBJ_DIR)/Logger_test.o \
 OBJS_ROUTINECONTROL_TEST = $(OBJ_DIR)/MemoryManager_test.o \
 						   $(OBJ_DIR)/Logger_test.o \
 			   			   $(OBJ_DIR)/GenerateFrames_test.o \
-			   			   $(OBJ_DIR)/RoutineControl_test.o
+			   			   $(OBJ_DIR)/RoutineControl_test.o \
+			   			   $(OBJ_DIR)/NegativeResponse_test.o \
+			   			   $(OBJ_DIR)/SecurityAccess_test.o
 					
 OBJS_ACCESSTIMINGPARAMETER_TEST = $(OBJ_DIR)/Logger_test.o \
 			   						 $(OBJ_DIR)/GenerateFrames_test.o \

--- a/src/uds/authentication/include/SecurityAccess.h
+++ b/src/uds/authentication/include/SecurityAccess.h
@@ -28,18 +28,6 @@ class SecurityAccess
     public:
     /* SID for SecurityAccess */
     static constexpr uint8_t SECURITY_ACCESS_SID = 0x27;
-    /* SubFunctionNotSupported */
-    static constexpr uint8_t SFNS = 0x12;
-    /* IncorrectMesssageLengthOrInvalidFormat */
-    static constexpr uint8_t IMLOIF = 0x13;
-    /* RequestSequenceError */
-    static constexpr uint8_t RSE = 0x24;
-    /* Invalid key */
-    static constexpr uint8_t IK = 0x35;
-    /* Exceeded nr of attempts */
-    static constexpr uint8_t ENOA = 0x36;
-    /* Required time delay not expired */
-    static constexpr uint8_t RTDNE = 0x37;
     /* Adjust delay timer here. */
     static constexpr uint8_t TIMEOUT_IN_SECONDS = 0x05;
     /* Adjust nr of attempts here. */

--- a/src/uds/authentication/src/SecurityAccess.cpp
+++ b/src/uds/authentication/src/SecurityAccess.cpp
@@ -1,5 +1,4 @@
 #include "../include/SecurityAccess.h"
-#include "../../../mcu/include/MCUModule.h"
 
 /* Set the default security access to false. */
 bool SecurityAccess::mcu_state = false;
@@ -58,7 +57,7 @@ std::vector<uint8_t> SecurityAccess::generateRandomBytes(size_t length)
 /* Function to convert the time value to a 5-byte representation in big-endian format */
 std::vector<uint8_t> SecurityAccess::convertTimeToCANFrame(uint32_t timeInSeconds)
 {
-    std::vector<uint8_t> frame = {0x07, 0x7F, SECURITY_ACCESS_SID, RTDNE};
+    std::vector<uint8_t> frame = {0x07, 0x7F, SECURITY_ACCESS_SID, NegativeResponse::RTDNE};
 
     /* Calculate number of non-zero bytes needed to represent timeInSeconds */
     std::vector<uint8_t> timeBytes;
@@ -121,7 +120,7 @@ void SecurityAccess::securityAccess(canid_t can_id, const std::vector<uint8_t>& 
             (request[2] == 0x02 && request[0] == 2)
             || (request.size() != static_cast<size_t>(request[0] + 1)))
         {
-            nrc.sendNRC(can_id,SECURITY_ACCESS_SID,IMLOIF);
+            nrc.sendNRC(can_id,SECURITY_ACCESS_SID,NegativeResponse::IMLOIF);
         }
         else
         {
@@ -130,7 +129,7 @@ void SecurityAccess::securityAccess(canid_t can_id, const std::vector<uint8_t>& 
             /* Subfunction not supported, we use only 1st lvl of security access. */
             if (sf != 0x01 && sf != 0x02)
             {
-                nrc.sendNRC(can_id,SECURITY_ACCESS_SID,SFNS);
+                nrc.sendNRC(can_id,SECURITY_ACCESS_SID,NegativeResponse::SFNS);
             }
             else if (sf == 0x01)
             {
@@ -164,7 +163,7 @@ void SecurityAccess::securityAccess(canid_t can_id, const std::vector<uint8_t>& 
                 if (security_access_seed.empty())
                 {
                     LOG_ERROR(security_logger.GET_LOGGER(), "Cannot have sendKey request before requestSeed.");
-                    nrc.sendNRC(can_id,SECURITY_ACCESS_SID,RSE);
+                    nrc.sendNRC(can_id,SECURITY_ACCESS_SID,NegativeResponse::RSE);
                 }
                 else if (time_left == 0)
                 {
@@ -194,7 +193,7 @@ void SecurityAccess::securityAccess(canid_t can_id, const std::vector<uint8_t>& 
                         if (nr_of_attempts > 0)
                         {
                             /* Invalid key, doesnt match with server's key. */
-                            nrc.sendNRC(can_id,SECURITY_ACCESS_SID,IK);
+                            nrc.sendNRC(can_id,SECURITY_ACCESS_SID,NegativeResponse::IK);
                             nr_of_attempts--;
                             LOG_INFO(security_logger.GET_LOGGER(), "{} attempts left.", nr_of_attempts);
                         }
@@ -206,7 +205,7 @@ void SecurityAccess::securityAccess(canid_t can_id, const std::vector<uint8_t>& 
                              * by this request(i.e. due to reaching the limit of false access attempts which activate
                              * the delay timer).
                             */
-                            nrc.sendNRC(can_id,SECURITY_ACCESS_SID,ENOA);
+                            nrc.sendNRC(can_id,SECURITY_ACCESS_SID,NegativeResponse::ENOA);
                                 
                             /* Start the delay timer clock. */
                             end_time = std::chrono::steady_clock::now() + std::chrono::seconds(TIMEOUT_IN_SECONDS);

--- a/src/uds/authentication/utest/SecurityAccessTest.cpp
+++ b/src/uds/authentication/utest/SecurityAccessTest.cpp
@@ -133,7 +133,7 @@ TEST_F(SecurityTest, DefaultMCUStateTest)
 TEST_F(SecurityTest, IncorrectMesssageLength)
 {
     struct can_frame result_frame = createFrame({0x03, 0x7F, 
-                    SecurityAccess::SECURITY_ACCESS_SID, SecurityAccess::IMLOIF});
+                    SecurityAccess::SECURITY_ACCESS_SID, NegativeResponse::IMLOIF});
 
     r->securityAccess(0xFA10, {0x03, 0x27, 0x03, 0x3F, 0x01, 0x00, 0x02});
     c1->capture();
@@ -144,7 +144,7 @@ TEST_F(SecurityTest, IncorrectMesssageLength)
 TEST_F(SecurityTest, SubFunctionNotSupported)
 {
     struct can_frame result_frame = createFrame({0x03, 0x7F, 
-                    SecurityAccess::SECURITY_ACCESS_SID, SecurityAccess::SFNS});
+                    SecurityAccess::SECURITY_ACCESS_SID, NegativeResponse::SFNS});
 
     r->securityAccess(0xFA10, {0x06, SecurityAccess::SECURITY_ACCESS_SID, 
                     0x03, 0x3F, 0x01, 0x00, 0x02});
@@ -156,7 +156,7 @@ TEST_F(SecurityTest, SubFunctionNotSupported)
 TEST_F(SecurityTest, SendKeyBeforeRequestSeed)
 {
     struct can_frame result_frame = createFrame({0x03, 0x7F, 
-                    SecurityAccess::SECURITY_ACCESS_SID, SecurityAccess::RSE});
+                    SecurityAccess::SECURITY_ACCESS_SID, NegativeResponse::RSE});
     r->securityAccess(0xFA10, {0x04, 0x27, 0x02, 0xCA, 0xA5});
     c1->capture();
     testFrames(result_frame, *c1);
@@ -187,7 +187,7 @@ TEST_F(SecurityTest, RequestSeed)
 TEST_F(SecurityTest, InvalidKey)
 {
     struct can_frame result_frame = createFrame({0x03, 0x7F, 
-                    SecurityAccess::SECURITY_ACCESS_SID, SecurityAccess::IK});
+                    SecurityAccess::SECURITY_ACCESS_SID, NegativeResponse::IK});
     /* Send 3 wrong key */
     std::vector<uint8_t> data_frame = {static_cast<uint8_t>(seed.size() + 2), 0x27, 0x02};
 
@@ -206,7 +206,7 @@ TEST_F(SecurityTest, InvalidKey)
 TEST_F(SecurityTest, ExceededNrOfAttempts)
 {
     struct can_frame result_frame = createFrame({0x03, 0x7F, 
-                    SecurityAccess::SECURITY_ACCESS_SID, SecurityAccess::ENOA});
+                    SecurityAccess::SECURITY_ACCESS_SID, NegativeResponse::ENOA});
     /* Send another wrong key */
     std::vector<uint8_t> data_frame = {static_cast<uint8_t>(seed.size() + 2), 0x27, 0x02};
     

--- a/src/uds/ecu_reset/include/EcuReset.h
+++ b/src/uds/ecu_reset/include/EcuReset.h
@@ -12,6 +12,8 @@
 #include "../../../utils/include/GenerateFrames.h"
 #include "../../../utils/include/CreateInterface.h"
 #include "../../../utils/include/Logger.h"
+#include "../../../utils/include/NegativeResponse.h"
+#include "../../authentication/include/SecurityAccess.h"
 
 #include <linux/can.h>
 #include <iostream>

--- a/src/uds/read_data_by_identifier/include/ReadDataByIdentifier.h
+++ b/src/uds/read_data_by_identifier/include/ReadDataByIdentifier.h
@@ -20,10 +20,13 @@
 #include "../../../utils/include/GenerateFrames.h"
 #include "../../utils/include/Logger.h"
 #include "../../../utils/include/NegativeResponse.h"
+#include "../../authentication/include/SecurityAccess.h"
 
 class ReadDataByIdentifier
 {
     public:
+    /* Define the service identifier for Read Data By Identifier */
+    static constexpr uint8_t RDBI_SERVICE_ID = 0x22;
     /**
     * @brief Default constructor
     */

--- a/src/uds/read_data_by_identifier/include/ReadDataByIdentifier.h
+++ b/src/uds/read_data_by_identifier/include/ReadDataByIdentifier.h
@@ -19,6 +19,7 @@
 
 #include "../../../utils/include/GenerateFrames.h"
 #include "../../utils/include/Logger.h"
+#include "../../../utils/include/NegativeResponse.h"
 
 class ReadDataByIdentifier
 {

--- a/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
+++ b/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
@@ -8,9 +8,6 @@ ReadDataByIdentifier::ReadDataByIdentifier(int socket, Logger* rdbi_logger)
     this->socket = socket;
 }
 
-/* Define the service identifier for Read Data By Identifier */
-const uint8_t RDBI_SERVICE_ID = 0x22;
-
 /* Function to handle the Read Data By Identifier request */
 std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, const std::vector<uint8_t>& request, bool use_send_frame) {
     std::vector<uint8_t> response;
@@ -29,14 +26,25 @@ std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, 
         response.push_back(0x03); /* PCI */
         response.push_back(0x7F); /* Negative response */
         response.push_back(RDBI_SERVICE_ID); /* Service ID */
-        response.push_back(0x13); /* Incorrect message length or invalid format */
+        response.push_back(NegativeResponse::IMLOIF); /* Incorrect message length or invalid format */
 
         if (use_send_frame) {
             /* Send the negative response frame */ 
-            nrc.sendNRC(can_id,RDBI_SERVICE_ID,13);
+            nrc.sendNRC(can_id,RDBI_SERVICE_ID,NegativeResponse::IMLOIF);
         }
 
         /* Return early as the request is invalid */
+        return response;
+    }
+    if (!SecurityAccess::getMcuState()) {
+        response.push_back(0x03); /* PCI */
+        response.push_back(0x7F); /* Negative response */
+        response.push_back(RDBI_SERVICE_ID); /* Service ID */
+        response.push_back(NegativeResponse::SAD); /* Security Access Denied */
+        if (use_send_frame) {
+            nrc.sendNRC(can_id,RDBI_SERVICE_ID,NegativeResponse::SAD);
+        }
+
         return response;
     }
 
@@ -57,7 +65,15 @@ std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, 
 
     } else {
         /* Data identifier not found */
-        LOG_ERROR(rdbi_logger.GET_LOGGER(), "Request out of range");
+        response.push_back(0x03); /* PCI */
+        response.push_back(0x7F); /* Negative response */
+        response.push_back(RDBI_SERVICE_ID); /* Service ID */
+        response.push_back(NegativeResponse::ROOR); /* Request out of range */
+        if (use_send_frame) {
+            /* Send the negative response frame */ 
+            nrc.sendNRC(can_id,RDBI_SERVICE_ID,NegativeResponse::ROOR);
+        }
+        return response;
     }
 
     if (use_send_frame) {

--- a/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
+++ b/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
@@ -14,6 +14,7 @@ const uint8_t RDBI_SERVICE_ID = 0x22;
 /* Function to handle the Read Data By Identifier request */
 std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, const std::vector<uint8_t>& request, bool use_send_frame) {
     std::vector<uint8_t> response;
+    NegativeResponse nrc(socket, rdbi_logger);
 
     /* Extract the first 8 bits of can_id */
     uint8_t lowerbits = can_id & 0xFF;
@@ -32,8 +33,7 @@ std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, 
 
         if (use_send_frame) {
             /* Send the negative response frame */ 
-            /* this will be replaced by NegativeResponse when done */
-            generate_frames.readDataByIdentifier(can_id, 0, response);
+            nrc.sendNRC(can_id,RDBI_SERVICE_ID,13);
         }
 
         /* Return early as the request is invalid */

--- a/src/uds/read_data_by_identifier/utest/ReadDataByIdentifierTest.cpp
+++ b/src/uds/read_data_by_identifier/utest/ReadDataByIdentifierTest.cpp
@@ -32,7 +32,7 @@ TEST_F(ReadDataByIdentifierTest, InvalidMessageLength) {
     std::vector<uint8_t> request = {0x22, 0x01, 0x12};
 
     std::vector<uint8_t> expected_response = {0x03, 0x7F, 0x22, 0x13};
-    std::vector<uint8_t> actual_response = rdbi->readDataByIdentifier(can_id, request, true);
+    std::vector<uint8_t> actual_response = rdbi->readDataByIdentifier(can_id, request, false);
 
     EXPECT_EQ(expected_response, actual_response);
 }
@@ -44,7 +44,7 @@ TEST_F(ReadDataByIdentifierTest, ValidRequestForMCUData) {
     std::vector<uint8_t> request = {0x22, 0x01, 0x12, 0x34};
 
     std::vector<uint8_t> expected_response = {0x01, 0x02, 0x03, 0x04};
-    std::vector<uint8_t> actual_response = rdbi->readDataByIdentifier(can_id, request, true);
+    std::vector<uint8_t> actual_response = rdbi->readDataByIdentifier(can_id, request, false);
 
     EXPECT_EQ(expected_response, actual_response);
 }
@@ -110,7 +110,7 @@ TEST_F(ReadDataByIdentifierTest, LongResponseForAPIFrame) {
     std::vector<uint8_t> long_data(10, 0xBB);
     MCU::mcu->mcu_data[0x1234] = long_data;
 
-    std::vector<uint8_t> actual_response = rdbi->readDataByIdentifier(can_id, request, true);
+    std::vector<uint8_t> actual_response = rdbi->readDataByIdentifier(can_id, request, false);
 
     std::vector<uint8_t> expected_response;
     expected_response.insert(expected_response.end(), long_data.begin(), long_data.end());

--- a/src/uds/read_data_by_identifier/utest/ReadDataByIdentifierTest.cpp
+++ b/src/uds/read_data_by_identifier/utest/ReadDataByIdentifierTest.cpp
@@ -32,7 +32,7 @@ TEST_F(ReadDataByIdentifierTest, InvalidMessageLength) {
     std::vector<uint8_t> request = {0x22, 0x01, 0x12};
 
     std::vector<uint8_t> expected_response = {0x03, 0x7F, 0x22, 0x13};
-    std::vector<uint8_t> actual_response = rdbi->readDataByIdentifier(can_id, request, false);
+    std::vector<uint8_t> actual_response = rdbi->readDataByIdentifier(can_id, request, true);
 
     EXPECT_EQ(expected_response, actual_response);
 }
@@ -44,7 +44,7 @@ TEST_F(ReadDataByIdentifierTest, ValidRequestForMCUData) {
     std::vector<uint8_t> request = {0x22, 0x01, 0x12, 0x34};
 
     std::vector<uint8_t> expected_response = {0x01, 0x02, 0x03, 0x04};
-    std::vector<uint8_t> actual_response = rdbi->readDataByIdentifier(can_id, request, false);
+    std::vector<uint8_t> actual_response = rdbi->readDataByIdentifier(can_id, request, true);
 
     EXPECT_EQ(expected_response, actual_response);
 }
@@ -110,7 +110,7 @@ TEST_F(ReadDataByIdentifierTest, LongResponseForAPIFrame) {
     std::vector<uint8_t> long_data(10, 0xBB);
     MCU::mcu->mcu_data[0x1234] = long_data;
 
-    std::vector<uint8_t> actual_response = rdbi->readDataByIdentifier(can_id, request, false);
+    std::vector<uint8_t> actual_response = rdbi->readDataByIdentifier(can_id, request, true);
 
     std::vector<uint8_t> expected_response;
     expected_response.insert(expected_response.end(), long_data.begin(), long_data.end());

--- a/src/uds/routine_control/include/RoutineControl.h
+++ b/src/uds/routine_control/include/RoutineControl.h
@@ -20,7 +20,7 @@
 class RoutineControl
 {
     public:
-    /* Define the service identifier for Read Data By Identifier */
+    /* Define the service identifier for Routine Control */
     static constexpr uint8_t ROUTINE_CONTROL_SID = 0x31;
     /**
     * @brief Default constructor

--- a/src/uds/routine_control/include/RoutineControl.h
+++ b/src/uds/routine_control/include/RoutineControl.h
@@ -14,10 +14,14 @@
 #include "../../../utils/include/GenerateFrames.h"
 #include "../../utils/include/Logger.h"
 #include "../../utils/include/MemoryManager.h"
+#include "../../../utils/include/NegativeResponse.h"
+#include "../../authentication/include/SecurityAccess.h"
 
 class RoutineControl
 {
     public:
+    /* Define the service identifier for Read Data By Identifier */
+    static constexpr uint8_t ROUTINE_CONTROL_SID = 0x31;
     /**
     * @brief Default constructor
     */

--- a/src/uds/routine_control/src/RoutineControl.cpp
+++ b/src/uds/routine_control/src/RoutineControl.cpp
@@ -9,7 +9,7 @@ RoutineControl::RoutineControl(int socket, Logger& rc_logger)
 /* Function to handle the RoutineControl request */
 void RoutineControl::routineControl(canid_t can_id, const std::vector<uint8_t>& request)
 {
-    uint16_t routine_identifier = request[3] << 8 | request[4]; 
+    uint16_t routine_identifier = request[3] << 8 | request[4];
     std::vector<uint8_t> response;
     NegativeResponse nrc(socket, rc_logger);
     uint8_t lowerbits = can_id & 0xFF;

--- a/src/uds/routine_control/src/RoutineControl.cpp
+++ b/src/uds/routine_control/src/RoutineControl.cpp
@@ -11,6 +11,7 @@ void RoutineControl::routineControl(canid_t can_id, const std::vector<uint8_t>& 
 {
     uint16_t routine_identifier = request[3] << 8 | request[4]; 
     std::vector<uint8_t> response;
+    NegativeResponse nrc(socket, rc_logger);
     uint8_t lowerbits = can_id & 0xFF;
     uint8_t upperbits = can_id >> 8 & 0xFF;
     /* reverse ids */
@@ -18,20 +19,24 @@ void RoutineControl::routineControl(canid_t can_id, const std::vector<uint8_t>& 
     if (request.size() < 6)
     {
         /* Incorrect message length or invalid format - prepare a negative response */
-        generate_frames.negativeResponse(can_id, 0x31, 0x13);
+        nrc.sendNRC(can_id,ROUTINE_CONTROL_SID,NegativeResponse::IMLOIF);
         return;
     }
     else if (request[2] < 0x01 || request [2] > 0x03)
     {
         /* Sub Function not supported - prepare a negative response */
-        generate_frames.negativeResponse(can_id, 0x31, 0x12);
+        nrc.sendNRC(can_id,ROUTINE_CONTROL_SID,NegativeResponse::SFNS);
         return;
+    }
+    else if (!SecurityAccess::getMcuState())
+    {
+        nrc.sendNRC(can_id,ROUTINE_CONTROL_SID,NegativeResponse::SAD);
     }
     /* when our identifiers will be defined, this range should be smaller */
     else if (routine_identifier < 0x0100 || routine_identifier > 0xEFFF)
     {
         /* Request Out of Range - prepare a negative response */
-        generate_frames.negativeResponse(can_id, 0x31, 0x31);
+        nrc.sendNRC(can_id,ROUTINE_CONTROL_SID,NegativeResponse::ROOR);
         return;
     }
     else

--- a/src/uds/write_data_by_identifier/include/WriteDataByIdentifier.h
+++ b/src/uds/write_data_by_identifier/include/WriteDataByIdentifier.h
@@ -26,6 +26,8 @@
 
 #include "../../../utils/include/GenerateFrames.h"
 #include "../../../utils/include/Logger.h"
+#include "../../../utils/include/NegativeResponse.h"
+#include "../../authentication/include/SecurityAccess.h"
 
 class WriteDataByIdentifier
 {
@@ -35,6 +37,8 @@ private:
     Logger& wdbi_logger;
 
 public:
+    /* Define the service identifier for WriteDataByIdentifier*/
+    static constexpr uint8_t WDBI_SID = 0x2E;
     /**
      * @brief Construct a new Write Data By Identifier object
      * 

--- a/src/uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp
+++ b/src/uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp
@@ -18,20 +18,19 @@ void WriteDataByIdentifier::WriteDataByIdentifierService(canid_t frame_id, std::
 
     std::vector<uint8_t> response;
     std::vector<uint8_t> data_parameter = {};
+    NegativeResponse nrc(socket, wdbi_logger);
+
+    /* Form the new id */
+    int id = ((frame_id & 0xFF) << 8) | ((frame_id >> 8) & 0xFF);
+
     /* Checks if frame_data has the required minimum length */
     if (frame_data.size() < 3)
     {
-        LOG_ERROR(wdbi_logger.GET_LOGGER(), "Incorrect Message Length or Invalid Format");
-        response.clear();
-        /* PCI */
-        response.push_back(0x03);
-        /* Negative response */
-        response.push_back(0x7F);
-        /* WDBI sid */
-        response.push_back(0x2E);
-        /* Incorrect message length or invalid format */
-        response.push_back(0x13);
-        /* call NegativeResponseService */
+        nrc.sendNRC(id,WDBI_SID,NegativeResponse::IMLOIF);
+    }
+    else if (!SecurityAccess::getMcuState())
+    {
+        nrc.sendNRC(id,WDBI_SID,NegativeResponse::SAD);
     }
     else
     {
@@ -102,23 +101,8 @@ void WriteDataByIdentifier::WriteDataByIdentifierService(canid_t frame_id, std::
         else 
         {
             LOG_ERROR(wdbi_logger.GET_LOGGER(), "Request Out Of Range: Identifier not found in memory");
-            /* Construct the response data */
-            response.clear();
-            /* PCI */
-            response.push_back(0x03);
-            /** WDBI response sid*/
-            response.push_back(0x7F);
-            /* First Identifier */
-            response.push_back(0x2E);
-            /* Second Identifier */
-            response.push_back(0x31);
-            response.clear();
-            /* call NegativeResponseService */
-            return;
+            nrc.sendNRC(id,WDBI_SID,NegativeResponse::ROOR);
         }
-
-        /* Form the new id */
-        int id = ((frame_id & 0xFF) << 8) | ((frame_id >> 8) & 0xFF);
 
         /* Check on which socket to send the frame */
         generate_frames.writeDataByIdentifier(id, did, {});

--- a/src/utils/include/NegativeResponse.h
+++ b/src/utils/include/NegativeResponse.h
@@ -25,6 +25,43 @@ class NegativeResponse
 {
     public:
         static const std::map<uint8_t, std::string> nrcMap;
+        /* SubFunction Not Supported */
+        static constexpr uint8_t SFNS = 0x12;
+        /* Incorrect Message Length Or Invalid Format */
+        static constexpr uint8_t IMLOIF = 0x13;
+        /* Response Too Long */
+        static constexpr uint8_t RTL = 0x14;
+        /* Conditions Not Correct */
+        static constexpr uint8_t CNC = 0x22;
+        /* Request Sequence Error */
+        static constexpr uint8_t RSE = 0x24;
+        /* No Response From Subnet Component */
+        static constexpr uint8_t NRSC = 0x25;
+        /* Request Out Of Range */
+        static constexpr uint8_t ROOR = 0x31;
+        /* Security Access Denied */
+        static constexpr uint8_t SAD = 0x33;
+        /* Authentication Required */
+        static constexpr uint8_t AR = 0x34;
+        /* Invalid Key */
+        static constexpr uint8_t IK = 0x35;
+        /* Exceeded Number Of Attempts */
+        static constexpr uint8_t ENOA = 0x36;
+        /* Required Time Delay Not Expired */
+        static constexpr uint8_t RTDNE = 0x37;
+        /* Upload Download Not Accepted */
+        static constexpr uint8_t UDNA = 0x70;
+        /* Transfer Data Suspended */
+        static constexpr uint8_t TDS = 0x71;
+        /* General Programming Failure */
+        static constexpr uint8_t GPF = 0x72;
+        /* Wrong Block Sequence Counter */
+        static constexpr uint8_t WBSC = 0x73;
+        /* Voltage Too High */
+        static constexpr uint8_t VTH = 0x92;
+        /* Voltage Too Low */
+        static constexpr uint8_t VTL = 0x93;
+
     private:
         GenerateFrames* generate_frames;
         Logger& nrc_logger;

--- a/src/utils/src/NegativeResponse.cpp
+++ b/src/utils/src/NegativeResponse.cpp
@@ -2,24 +2,24 @@
 
 const std::map<uint8_t, std::string> NegativeResponse::nrcMap =
 {
-    {0x12, "SubFunction Not Supported"},
-    {0x13, "Incorrect Message Length Or Invalid Format"},
-    {0x14, "Response Too Long"},
-    {0x22, "Conditions Not Correct"},
-    {0x24, "Request Sequence Error"},
-    {0x25, "No Response From Subnet Component"},
-    {0x31, "Request Out Of Range"},
-    {0x33, "Security Access Denied"},
-    {0x34, "Authentication Required"},
-    {0x35, "Invalid Key"},
-    {0x36, "Exceeded Number Of Attempts"},
-    {0x37, "Required Time Delay NotExpired"},
-    {0x70, "Upload Download Not Accepted"},
-    {0x71, "Transfer Data Suspended"},
-    {0x72, "General Programming Failure"},
-    {0x73, "Wrong Block Sequence Counter"},
-    {0x92, "Voltage Too High"},
-    {0x93, "Voltage Too Low"}
+    {SFNS, "SubFunction Not Supported"},
+    {IMLOIF, "Incorrect Message Length Or Invalid Format"},
+    {RTL, "Response Too Long"},
+    {CNC, "Conditions Not Correct"},
+    {RSE, "Request Sequence Error"},
+    {NRSC, "No Response From Subnet Component"},
+    {ROOR, "Request Out Of Range"},
+    {SAD, "Security Access Denied"},
+    {AR, "Authentication Required"},
+    {IK, "Invalid Key"},
+    {ENOA, "Exceeded Number Of Attempts"},
+    {RTDNE, "Required Time Delay Not Expired"},
+    {UDNA, "Upload Download Not Accepted"},
+    {TDS, "Transfer Data Suspended"},
+    {GPF, "General Programming Failure"},
+    {WBSC, "Wrong Block Sequence Counter"},
+    {VTH, "Voltage Too High"},
+    {VTL, "Voltage Too Low"}
 };
 
 NegativeResponse::NegativeResponse(int socket, Logger& nrc_logger)


### PR DESCRIPTION
## Description

-Integrated SecurityAccess into: ECU Reset, readDatabyIdentifier, writeDataByIdentifier, routineControl
-Solved some bugs related to makefile rules(testerpresent and negative class)
-Discoverd bugs on rdbi and wdbi(on rdbi i fixed)
-Integrated Negative Response class into all of them
-Added the 2 main negative response cases according to general flow for negative response which need to be done before security check where they are not present
-Refactor Negative Response Class so that everyone can use the codes(they are public static, can be used without object class)

**Things to be done in the future: implement IPC logic such as ecu can access services when server is unlocked(MCU and ECU are 2 different processes), i tried shared memory but this will work only when the 2 processes run on the same Raspberry PI; Fix unit tests for those services (they halt when they reach security check, because security is default false so therefore if you dont unlock server, you cant test the flow below this check)**

## Trello link [here](https://trello.com/c/b6otes1T/28-integrate-securityaccess-in-uds-ota-services-according-to-documentation-from-drive)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
