### PR TITLE
TesterPresent integration with DiagnosticSessionControl

### DIFF
--- a/src/ecu_simulation/BatteryModule/src/HandleFrames.cpp
+++ b/src/ecu_simulation/BatteryModule/src/HandleFrames.cpp
@@ -477,7 +477,7 @@ void HandleFrames::handleCompleteData(int id,const std::vector<uint8_t>& stored_
                 LOG_INFO(batteryModuleLogger->GET_LOGGER(), "Data size: {}", stored_data.size());
                 sub_function = stored_data[sid_position + 1];
                 LOG_INFO(batteryModuleLogger->GET_LOGGER(), "sub_function: {}", static_cast<int>(sub_function));
-                TesterPresent tester_present(*batteryModuleLogger, socket, 10000);
+                TesterPresent tester_present(batteryModuleLogger, &diagnosticSessionControl, socket, 10000);
                 tester_present.handleTesterPresent(id, stored_data);
 
                 if (stored_data[1] == 0x7F)

--- a/src/mcu/src/HandleFrames.cpp
+++ b/src/mcu/src/HandleFrames.cpp
@@ -208,7 +208,7 @@ namespace MCU
                 else 
                 {
                     LOG_INFO(MCULogger->GET_LOGGER(), "TesterPresent called.");
-                    TesterPresent tester_present(*MCULogger, getMcuSocket(frame_id));
+                    TesterPresent tester_present(MCULogger, &mcuDiagnosticSessionControl, getMcuSocket(frame_id), 1000);
                     tester_present.handleTesterPresent(frame_id, frame_data);
                 }
                 break;

--- a/src/uds/tester_present/include/TesterPresent.h
+++ b/src/uds/tester_present/include/TesterPresent.h
@@ -9,6 +9,7 @@
 
 #include "../../../utils/include/GenerateFrames.h"
 #include "../../../utils/include/CreateInterface.h"
+#include "../../diagnostic_session_control/include/DiagnosticSessionControl.h"
 #include <iostream>
 #include <vector>
 #include <thread>
@@ -19,11 +20,12 @@ class TesterPresent
 {
 private:
     GenerateFrames* generate;
+    DiagnosticSessionControl* sessionControl;
+    Logger* logger;
     std::thread timerThread;
     std::atomic<bool> running;
-    Logger logger;
     int socket;
-    int timeout_duration = 5;
+    int timeout_duration;
 
 public:
     /**
@@ -32,8 +34,9 @@ public:
      * @param logger Logger instance
      * @param socket CAN socket
      * @param timeout_duration Duration for the S3 timer in seconds
+     * @param sessionControl DiagnosticSessionControl instance
      */
-    TesterPresent(Logger logger, int socket, int timeout_duration = 5);
+    TesterPresent(Logger* logger, DiagnosticSessionControl* sessionControl, int socket, int timeout_duration);
     TesterPresent();
 
     /**


### PR DESCRIPTION
## Description

added a DiagnosticSessionControl object in TesterPresent class and pass it by refference in TesterPresent constructor;
switch to default session when S3 timer expires using diagnostic session control service.

## Trello link [here](https://trello.com/c/Zk4T5pfi)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
