### PR TITLE
DSC&ATP services integration

### DIFF
--- a/src/ecu_simulation/BatteryModule/include/BatteryModule.h
+++ b/src/ecu_simulation/BatteryModule/include/BatteryModule.h
@@ -23,6 +23,8 @@
 #include <cstdlib>
 #include <chrono>
 #include <iostream>
+#include <unistd.h>
+#include <future>
 #include "../../../utils/include/CreateInterface.h"
 #include "ReceiveFrames.h"
 #include "../../../utils/include/GenerateFrames.h"
@@ -43,6 +45,12 @@ private:
     ReceiveFrames* frameReceiver;
 
 public:
+    /* Static dictionary to store SID and processing time */
+    static std::map<uint8_t, double> timing_parameters;
+    /* Store active timers for SIDs */
+    static std::map<uint8_t, std::future<void>> active_timers;
+    /* Stop flags for each SID. */
+    static std::map<uint8_t, std::atomic<bool>> stop_flags;
     /* Variable to store ecu data */
     std::unordered_map<uint16_t, std::vector<uint8_t>> ecu_data = {
         {0x01A0, {0}},  /* Energy Level */

--- a/src/ecu_simulation/BatteryModule/include/ReceiveFrames.h
+++ b/src/ecu_simulation/BatteryModule/include/ReceiveFrames.h
@@ -30,9 +30,29 @@
 #include <condition_variable>
 #include <atomic>
 #include <poll.h> 
+#include <future>
 #include "../include/HandleFrames.h"
 #include "../include/GenerateFrames.h"
 #include "../include/BatteryModuleLogger.h"
+
+  /* List of service we have implemented. */
+  const std::vector<uint8_t> service_sids = {
+    0x11, // ECU Reset
+    0x10, // Diagnostic Session Control
+    0x22, // Read Data By Identifier
+    0x29, // Authentication
+    0x31, // Routine Control (Testing) -> will be decided
+    0x3E, // Tester Present
+    0x23, // Read Memory By Address
+    0x2E, // Write Data By Identifier
+    0x19, // Read DTC Information
+    0x14, // Clear Diagnostic Information
+    0x83, // Access Timing Parameters
+    0x34, // Request Download
+    0x36, // Transfer Data
+    0x37, // Request Transfer Exit
+    0x32  // Request update status
+};
 
 class ReceiveFrames 
 {
@@ -65,11 +85,17 @@ private:
      * @param handle_frame HandleFrame object used for getting new frames.
      */
     void bufferFrameOut(HandleFrames &handle_frame);
+
+    /* Method that start time processing frame. */
+    void startTimer(uint8_t sid);
+    /* Method that stop time processing frame. */
+    void stopTimer(uint8_t sid);
     
 protected:
     HandleFrames handle_frame;
     
 public:
+
     /**
      * @brief Parameterized constructor.
      * 

--- a/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
+++ b/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
@@ -3,6 +3,11 @@
 
 Logger* batteryModuleLogger = nullptr;
 BatteryModule* battery = nullptr;
+
+std::map<uint8_t, double> BatteryModule::timing_parameters;
+std::map<uint8_t, std::future<void>> BatteryModule::active_timers;
+std::map<uint8_t, std::atomic<bool>> BatteryModule::stop_flags;
+
 /** Constructor - initializes the BatteryModule with default values,
  * sets up the CAN interface, and prepares the frame receiver. */
 BatteryModule::BatteryModule() : moduleId(0x11),

--- a/src/ecu_simulation/BatteryModule/src/ReceiveFrames.cpp
+++ b/src/ecu_simulation/BatteryModule/src/ReceiveFrames.cpp
@@ -1,4 +1,5 @@
 #include "../include/ReceiveFrames.h"
+#include "../../../ecu_simulation/BatteryModule/include/BatteryModule.h"
 
 ReceiveFrames::ReceiveFrames(int socket, int frame_id) : socket(socket), frame_id(frame_id), running(true) 
 {
@@ -131,6 +132,14 @@ void ReceiveFrames::bufferFrameOut(HandleFrames &handle_frame)
 
         uint8_t frame_dest_id = frame.can_id & 0xFF;
         current_module_id = frame_id & 0xFF;
+
+        /* Starting frame processing timing if is it a frame request for MCU */
+        auto it = std::find(service_sids.begin(), service_sids.end(), frame.data[1]);
+
+        if (it != service_sids.end() && frame_dest_id == 0x11) {
+            startTimer(frame.data[1]);
+        }
+
         /* Check if the received frame is for your module */ 
         if (static_cast<int>(frame_dest_id) != current_module_id)
         {
@@ -173,6 +182,42 @@ void ReceiveFrames::bufferFrameOut(HandleFrames &handle_frame)
         if (!handle_frame.checkReceivedFrame(nbytes, frame)) {
             LOG_WARN(batteryModuleLogger->GET_LOGGER(), "Failed to process frame\n");
         }
+    }
+}
+
+void ReceiveFrames::startTimer(uint8_t sid) {
+    LOG_INFO(batteryModuleLogger->GET_LOGGER(), "Started frame processing timing for frame with SID {:x}.", sid);
+    auto start_time = std::chrono::steady_clock::now();
+    battery->timing_parameters[sid] = start_time.time_since_epoch().count();
+
+    // Initialize stop flag for this SID
+    battery->stop_flags[sid] = true;
+
+    battery->active_timers[sid] = std::async(std::launch::async, [sid, this, start_time]() {
+        while (BatteryModule::stop_flags[sid]) {
+            auto now = std::chrono::steady_clock::now();
+            std::chrono::duration<double> elapsed = now - start_time;
+            if (elapsed.count() > AccessTimingParameter::p2_max_time / 20) {
+                stopTimer(sid);
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    });
+}
+
+void ReceiveFrames::stopTimer(uint8_t sid) {
+    LOG_INFO(batteryModuleLogger->GET_LOGGER(), "stopTimer function called for frame with SID {:x}.", sid);
+    auto end_time = std::chrono::steady_clock::now();
+    auto start_time = std::chrono::steady_clock::time_point(std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::nanoseconds((long long)battery->timing_parameters[sid])));
+    std::chrono::duration<double> processing_time = end_time - start_time;
+
+    battery->timing_parameters[sid] = processing_time.count();
+
+    if (BatteryModule::active_timers.find(sid) != BatteryModule::active_timers.end()) {
+        // Set stop flag to false for this SID
+        battery->stop_flags[sid] = false;
+        battery->stop_flags.erase(sid);
+        battery->active_timers[sid].wait();
     }
 }
 

--- a/src/mcu/include/MCUModule.h
+++ b/src/mcu/include/MCUModule.h
@@ -15,10 +15,18 @@
 #include "../../uds/tester_present/include/TesterPresent.h"
 
 #include <thread>
+#include <future>
 namespace MCU
 {
     class MCUModule {
     public:
+        /* Static dictionary to store SID and processing time */
+        static std::map<uint8_t, double> timing_parameters;
+        /* Store active timers for SIDs */
+        static std::map<uint8_t, std::future<void>> active_timers;
+        /* Stop flags for each SID. */
+        static std::map<uint8_t, std::atomic<bool>> stop_flags;
+
         /* Variable to store mcu data */
         std::unordered_map<uint16_t, std::vector<uint8_t>> mcu_data;
         /** 

--- a/src/mcu/include/ReceiveFrames.h
+++ b/src/mcu/include/ReceiveFrames.h
@@ -50,12 +50,34 @@
 #include<map>
 #include<chrono>
 #include<thread>
+#include <future>
+#include <atomic>
 
-#include "HandleFrames.h"
+#include "../include/HandleFrames.h"
 #include "../../utils/include/GenerateFrames.h"
 #include "../include/MCULogger.h"
+
 namespace MCU
 {
+  /* List of service we have implemented. */
+  const std::vector<uint8_t> service_sids = {
+    0x11, // ECU Reset
+    0x10, // Diagnostic Session Control
+    0x22, // Read Data By Identifier
+    0x29, // Authentication
+    0x31, // Routine Control (Testing) -> will be decided
+    0x3E, // Tester Present
+    0x23, // Read Memory By Address
+    0x2E, // Write Data By Identifier
+    0x19, // Read DTC Information
+    0x14, // Clear Diagnostic Information
+    0x83, // Access Timing Parameters
+    0x34, // Request Download
+    0x36, // Transfer Data
+    0x37, // Request Transfer Exit
+    0x32  // Request update status
+};
+
   class ReceiveFrames
   {
   public:
@@ -150,6 +172,11 @@ namespace MCU
     std::chrono::seconds timeout_duration;
     std::thread timer_thread;
     bool running;
+
+    /* Method that start time processing frame. */
+    void startTimer(uint8_t sid);
+    /* Method that stop time processing frame. */
+    void stopTimer(uint8_t sid);
     
   protected:
     /* The socket from where we read the frames */

--- a/src/mcu/src/HandleFrames.cpp
+++ b/src/mcu/src/HandleFrames.cpp
@@ -141,7 +141,8 @@ namespace MCU
                     processNrc(frame_id, sid, frame_data[3]);
                 }
                 else 
-                {    
+                {   
+                    /* This service can be called in any session */
                     LOG_INFO(MCULogger->GET_LOGGER(), "DiagnosticSessionControl called.");
                     mcuDiagnosticSessionControl.sessionControl(frame_id, frame_data[2]);
                     LOG_INFO(MCULogger->GET_LOGGER(), "MCU Current session: {}", DiagnosticSessionControl::getCurrentSessionToString());
@@ -161,9 +162,10 @@ namespace MCU
                     uint8_t sub_function = frame_data[2];
                     LOG_INFO(MCULogger->GET_LOGGER(), "sub_function: {}", static_cast<int>(sub_function));
 
-                    /* Calls ECU Reset */                
+                    /* Calls ECU Reset */      
+                    /* This service can be called in any session. */
                     EcuReset ecu_reset(frame_id, sub_function, getMcuSocket(frame_id), *MCULogger);
-                    ecu_reset.ecuResetRequest();
+                    ecu_reset.ecuResetRequest();         
                 }
                 break;
             }
@@ -175,16 +177,26 @@ namespace MCU
                 }
                 else
                 {
-                    LOG_INFO(MCULogger->GET_LOGGER(), "SecurityAccess called.");
-                    SecurityAccess security_access(getMcuSocket(frame_id), *MCULogger);
-                    security_access.securityAccess(frame_id, frame_data);
-                    if (SecurityAccess::getMcuState())
+                    /* This service can be called in PROGRAMMING_SESSION */
+                    if(DiagnosticSessionControl::getCurrentSessionToString() == "PROGRAMMING_SESSION")
                     {
-                        LOG_INFO(MCULogger->GET_LOGGER(), "Server is unlocked.");
+                        LOG_INFO(MCULogger->GET_LOGGER(), "SecurityAccess called.");
+                        SecurityAccess security_access(getMcuSocket(frame_id), *MCULogger);
+                        security_access.securityAccess(frame_id, frame_data);
+                        if (SecurityAccess::getMcuState())
+                        {
+                            LOG_INFO(MCULogger->GET_LOGGER(), "Server is unlocked.");
+                        }
+                        else
+                        {
+                            LOG_INFO(MCULogger->GET_LOGGER(), "Server is locked.");
+                        }
                     }
                     else
                     {
-                        LOG_INFO(MCULogger->GET_LOGGER(), "Server is locked.");
+                        int new_id = ((frame_id & 0xFF) << 8) | ((frame_id >> 8) & 0xFF);
+                        NegativeResponse negative_response(getMcuSocket(frame_id), *MCULogger);
+                        negative_response.sendNRC(new_id, 0x83, 0x7E);
                     }
                 }
                 break;
@@ -220,6 +232,7 @@ namespace MCU
                 }
                 else 
                 {
+                    /* This service can be called in any session. */
                     LOG_INFO(MCULogger->GET_LOGGER(), "AccessTimingParameters called.");
                     AccessTimingParameter access_timing_parameter(*MCULogger, getMcuSocket(frame_id));
                     if(frame_data.size() < 4)
@@ -241,6 +254,7 @@ namespace MCU
                 }
                 else 
                 {
+                    /* This service can be called in any session */
                     LOG_INFO(MCULogger->GET_LOGGER(), "ReadDataByIdentifier called.");
                     ReadDataByIdentifier read_data_by_identifier(getMcuSocket(frame_id), MCULogger);
                     read_data_by_identifier.readDataByIdentifier(frame_id, frame_data, true);
@@ -265,6 +279,7 @@ namespace MCU
                 }
                 else 
                 {
+                    /* This service can be called in any session. */
                     LOG_INFO(MCULogger->GET_LOGGER(), "WriteDataByIdentifier service called!");
                     WriteDataByIdentifier write_data_by_identifier(*MCULogger, getMcuSocket(frame_id));
                     write_data_by_identifier.WriteDataByIdentifierService(frame_id, frame_data);
@@ -278,6 +293,7 @@ namespace MCU
                 }
                 else 
                 {
+                    /* This service can be called in any session */
                     LOG_INFO(MCULogger->GET_LOGGER(), "ClearDiagnosticInformation called.");
                     ClearDtc clear_dtc("../uds/read_dtc_information/dtcs.txt", *MCULogger, getMcuSocket(frame_id));
                     clear_dtc.clearDtc(frame_id, frame_data);
@@ -291,6 +307,7 @@ namespace MCU
                 }
                 else 
                 {
+                    /* This service can be called in any session */
                     LOG_INFO(MCULogger->GET_LOGGER(), "ReadDtcInformation called.");
                     /* verify_frame() */
                     ReadDTC readDtc(*MCULogger, "../uds/read_dtc_information/dtcs.txt", getMcuSocket(frame_id));
@@ -305,6 +322,7 @@ namespace MCU
                 }
                 else 
                 {
+                    /* This service can be called in any session. */
                     RoutineControl routine_control(getMcuSocket(frame_id), *MCULogger);
                     routine_control.routineControl(frame_id, frame_data);
                     LOG_INFO(MCULogger->GET_LOGGER(), "RoutineControl called.");
@@ -389,10 +407,21 @@ namespace MCU
                     LOG_INFO(MCULogger->GET_LOGGER(), "Service 0x34 RequestDownload");
                     LOG_INFO(MCULogger->GET_LOGGER(), "SID pos: {}", sid);
                     LOG_INFO(MCULogger->GET_LOGGER(), "Data size: {}", frame_data.size());
-                    RequestDownloadService requestDownload(getMcuSocket(frame_id), *MCULogger);
-                    ReadDataByIdentifier software_version(getMcuSocket(frame_id), MCULogger);
-                    SecurityAccess logged_in(getMcuSocket(frame_id), *MCULogger);
-                    requestDownload.requestDownloadRequest(frame_id, frame_data);
+
+                    /* This service can be called in PROGRAMMING_SESSION */
+                    if(DiagnosticSessionControl::getCurrentSessionToString() == "PROGRAMMING_SESSION")
+                    {
+                        RequestDownloadService requestDownload(getMcuSocket(frame_id), *MCULogger);
+                        ReadDataByIdentifier software_version(getMcuSocket(frame_id), MCULogger);
+                        SecurityAccess logged_in(getMcuSocket(frame_id), *MCULogger);
+                        requestDownload.requestDownloadRequest(frame_id, frame_data);
+                    }
+                    else
+                    {
+                        int new_id = ((frame_id & 0xFF) << 8) | ((frame_id >> 8) & 0xFF);
+                        NegativeResponse negative_response(getMcuSocket(frame_id), *MCULogger);
+                        negative_response.sendNRC(new_id, 0x34, 0x7F);
+                    }
                 }
                 break;
             case 0x36:
@@ -407,9 +436,19 @@ namespace MCU
                 }
                 else 
                 {
-                    TransferData transfer_data(getMcuSocket(frame_id), *MCULogger);
-                    transfer_data.transferData(frame_id, frame_data);
-                    LOG_INFO(MCULogger->GET_LOGGER(), "TransferData called with one frame.");
+                    /* This service can be called in PROGRAMMING_SESSION */
+                    if(DiagnosticSessionControl::getCurrentSessionToString() == "PROGRAMMING_SESSION")
+                    {
+                        TransferData transfer_data(getMcuSocket(frame_id), *MCULogger);
+                        transfer_data.transferData(frame_id, frame_data);
+                        LOG_INFO(MCULogger->GET_LOGGER(), "TransferData called with one frame.");
+                    }
+                    else
+                    {
+                         int new_id = ((frame_id & 0xFF) << 8) | ((frame_id >> 8) & 0xFF);
+                        NegativeResponse negative_response(getMcuSocket(frame_id), *MCULogger);
+                        negative_response.sendNRC(new_id, 0x36, 0x7F);
+                    }
                 }
                 break;
             case 0x37:
@@ -420,10 +459,19 @@ namespace MCU
                 }
                 else 
                 {
-                    LOG_INFO(MCULogger->GET_LOGGER(), "Request Transfer Exit Service 0x37 called");
-                    RequestTransferExit request_transfer_exit(getMcuSocket(frame_id), *MCULogger);
-                    request_transfer_exit.requestTRansferExitRequest(frame_id, frame_data);
-                    LOG_INFO(MCULogger->GET_LOGGER(), "RequestTransferExit called.");
+                    /* This service can be called in PROGRAMMING_SESSION */
+                    if(DiagnosticSessionControl::getCurrentSessionToString() == "PROGRAMMING_SESSION")
+                    {
+                        LOG_INFO(MCULogger->GET_LOGGER(), "Request Transfer Exit Service 0x37 called");
+                        RequestTransferExit request_transfer_exit(getMcuSocket(frame_id), *MCULogger);
+                        request_transfer_exit.requestTRansferExitRequest(frame_id, frame_data);
+                    }
+                    else
+                    {
+                        int new_id = ((frame_id & 0xFF) << 8) | ((frame_id >> 8) & 0xFF);
+                        NegativeResponse negative_response(getMcuSocket(frame_id), *MCULogger);
+                        negative_response.sendNRC(new_id, 0x37, 0x7F);
+                    }
                 }
                 break;
             case 0x32:
@@ -434,9 +482,19 @@ namespace MCU
                 }
                 else 
                 {
-                    LOG_INFO(MCULogger->GET_LOGGER(), "RequestUpdateStatus called.");
-                    RequestUpdateStatus RUS(getMcuSocket(frame_id));
-                    RUS.requestUpdateStatus(frame_id, frame_data);
+                    /* This service can be called in PROGRAMMING_SESSION */
+                    if(DiagnosticSessionControl::getCurrentSessionToString() == "PROGRAMMING_SESSION")
+                    {
+                        LOG_INFO(MCULogger->GET_LOGGER(), "RequestUpdateStatus called.");
+                        RequestUpdateStatus RUS(getMcuSocket(frame_id));
+                        RUS.requestUpdateStatus(frame_id, frame_data);
+                    }
+                    else
+                    {
+                        int new_id = ((frame_id & 0xFF) << 8) | ((frame_id >> 8) & 0xFF);
+                        NegativeResponse negative_response(getMcuSocket(frame_id), *MCULogger);
+                        negative_response.sendNRC(new_id, 0x32, 0x7F);
+                    }
                 }
                 break;
             /* OTA Responses */

--- a/src/mcu/src/MCUModule.cpp
+++ b/src/mcu/src/MCUModule.cpp
@@ -4,6 +4,9 @@ Logger* MCULogger = nullptr;
 namespace MCU
 {
     MCUModule* mcu = nullptr;
+    std::map<uint8_t, double> MCUModule::timing_parameters;
+    std::map<uint8_t, std::future<void>> MCUModule::active_timers;
+    std::map<uint8_t, std::atomic<bool>> MCUModule::stop_flags;
     /* Constructor */
     MCUModule::MCUModule(uint8_t interfaces_number) : 
                     is_running(false),

--- a/src/uds/access_timing_parameters/include/AccessTimingParameter.h
+++ b/src/uds/access_timing_parameters/include/AccessTimingParameter.h
@@ -24,6 +24,7 @@
 
 #include "../../../utils/include/GenerateFrames.h"
 #include "../../../utils/include/Logger.h"
+#include "../../../utils/include/NegativeResponse.h"
 
 #include <linux/can.h>
 #include <cstdlib>

--- a/src/uds/access_timing_parameters/src/AccessTimingParameter.cpp
+++ b/src/uds/access_timing_parameters/src/AccessTimingParameter.cpp
@@ -1,4 +1,6 @@
 #include "../include/AccessTimingParameter.h"
+#include "../../../ecu_simulation/BatteryModule/include/BatteryModule.h"
+#include "../../../mcu/include/MCUModule.h"
 
 // Define static constants
 const uint16_t AccessTimingParameter::DEFAULT_P2_MAX_TIME = 40;
@@ -79,8 +81,39 @@ void AccessTimingParameter::readExtendedTimingParameters(canid_t frame_id)
 
     GenerateFrames response_frame(socket, atp_logger);
     int id = ((frame_id & 0xFF) << 8) | ((frame_id >> 8) & 0xFF);
-    LOG_INFO(atp_logger.GET_LOGGER(), "Access timing Parameter method from GenerateFrames called.");
-    response_frame.accessTimingParameters(id, 0x01, response, true);
+
+    uint8_t receiver_id = frame_id & 0xFF;
+    switch(receiver_id)
+        {
+            case 0x10:
+                if (MCU::mcu->stop_flags.find(0x83) != MCU::mcu->stop_flags.end())
+                {
+                    /* Send response frame */
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x83);
+                    response_frame.accessTimingParameters(id, 0x01, response, true);
+                } else
+                {
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x83);
+                    NegativeResponse negative_response(socket, atp_logger);
+                    negative_response.sendNRC(id, 0x83, 0x78);
+                }
+                break;
+            case 0x11:
+                if (battery->stop_flags.find(0x2E) != battery->stop_flags.end())
+                {
+                    /* Send response frame */
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x83);
+                    response_frame.accessTimingParameters(id, 0x01, response, true);
+                } else
+                {
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x83);
+                    NegativeResponse negative_response(socket, atp_logger);
+                    negative_response.sendNRC(id, 0x83, 0x78);
+                }
+                break;
+            default:
+                LOG_ERROR(atp_logger.GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);
+        }
 }
 
 void AccessTimingParameter::setTimingParametersToDefault(canid_t frame_id)
@@ -98,8 +131,39 @@ void AccessTimingParameter::setTimingParametersToDefault(canid_t frame_id)
 
     GenerateFrames response_frame(socket, atp_logger);
     int id = ((frame_id & 0xFF) << 8) | ((frame_id >> 8) & 0xFF);
-    LOG_INFO(atp_logger.GET_LOGGER(), "Access timing Parameter method from GenerateFrames called.");
-    response_frame.accessTimingParameters(id, 0x02, {}, true);
+
+    uint8_t receiver_id = frame_id & 0xFF;
+    switch(receiver_id)
+        {
+            case 0x10:
+                if (MCU::mcu->stop_flags.find(0x83) != MCU::mcu->stop_flags.end())
+                {
+                    /* Send response frame */
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x83);
+                    response_frame.accessTimingParameters(id, 0x02, {}, true);
+                } else
+                {
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x83);
+                    NegativeResponse negative_response(socket, atp_logger);
+                    negative_response.sendNRC(id, 0x83, 0x78);
+                }
+                break;
+            case 0x11:
+                if (battery->stop_flags.find(0x2E) != battery->stop_flags.end())
+                {
+                    /* Send response frame */
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x83);
+                    response_frame.accessTimingParameters(id, 0x02, {}, true);
+                } else
+                {
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x83);
+                    NegativeResponse negative_response(socket, atp_logger);
+                    negative_response.sendNRC(id, 0x83, 0x78);
+                }
+                break;
+            default:
+                LOG_ERROR(atp_logger.GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);
+        }
 }
 
 void AccessTimingParameter::readCurrentlyActiveTimingParameters(canid_t frame_id)
@@ -129,8 +193,39 @@ void AccessTimingParameter::readCurrentlyActiveTimingParameters(canid_t frame_id
 
     GenerateFrames response_frame(socket, atp_logger);
     int id = ((frame_id & 0xFF) << 8) | ((frame_id >> 8) & 0xFF);
-    LOG_INFO(atp_logger.GET_LOGGER(), "Access timing Parameter method from GenerateFrames called.");
-    response_frame.accessTimingParameters(id, 0x03, response, true);
+
+    uint8_t receiver_id = frame_id & 0xFF;
+    switch(receiver_id)
+        {
+            case 0x10:
+                if (MCU::mcu->stop_flags.find(0x83) != MCU::mcu->stop_flags.end())
+                {
+                    /* Send response frame */
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x83);
+                    response_frame.accessTimingParameters(id, 0x03, response, true);
+                } else
+                {
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x83);
+                    NegativeResponse negative_response(socket, atp_logger);
+                    negative_response.sendNRC(id, 0x83, 0x78);
+                }
+                break;
+            case 0x11:
+                if (battery->stop_flags.find(0x83) != battery->stop_flags.end())
+                {
+                    /* Send response frame */
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x83);
+                    response_frame.accessTimingParameters(id, 0x03, response, true);
+                } else
+                {
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x83);
+                    NegativeResponse negative_response(socket, atp_logger);
+                    negative_response.sendNRC(id, 0x83, 0x78);
+                }
+                break;
+            default:
+                LOG_ERROR(atp_logger.GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);
+        }
 }
 
 void AccessTimingParameter::setTimingParameters(canid_t frame_id, std::vector<uint8_t> frame_data)
@@ -158,6 +253,37 @@ void AccessTimingParameter::setTimingParameters(canid_t frame_id, std::vector<ui
 
     GenerateFrames response_frame(socket, atp_logger);
     int id = ((frame_id & 0xFF) << 8) | ((frame_id >> 8) & 0xFF);
-    LOG_INFO(atp_logger.GET_LOGGER(), "Access timing Parameter method from GenerateFrames called.");
-    response_frame.accessTimingParameters(id, 0x04, response, true);
+
+    uint8_t receiver_id = frame_id & 0xFF;
+    switch(receiver_id)
+        {
+            case 0x10:
+                if (MCU::mcu->stop_flags.find(0x83) != MCU::mcu->stop_flags.end())
+                {
+                    /* Send response frame */
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x83);
+                    response_frame.accessTimingParameters(id, 0x04, response, true);
+                } else
+                {
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x83);
+                    NegativeResponse negative_response(socket, atp_logger);
+                    negative_response.sendNRC(id, 0x83, 0x78);
+                }
+                break;
+            case 0x11:
+                if (battery->stop_flags.find(0x83) != battery->stop_flags.end())
+                {
+                    /* Send response frame */
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x83);
+                    response_frame.accessTimingParameters(id, 0x04, response, true);
+                } else
+                {
+                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x83);
+                    NegativeResponse negative_response(socket, atp_logger);
+                    negative_response.sendNRC(id, 0x83, 0x78);
+                }
+                break;
+            default:
+                LOG_ERROR(atp_logger.GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);
+        }
 }

--- a/src/uds/authentication/src/SecurityAccess.cpp
+++ b/src/uds/authentication/src/SecurityAccess.cpp
@@ -1,4 +1,6 @@
 #include "../include/SecurityAccess.h"
+#include "../../../ecu_simulation/BatteryModule/include/BatteryModule.h"
+#include "../../../mcu/include/MCUModule.h"
 
 /* Set the default security access to false. */
 bool SecurityAccess::mcu_state = false;

--- a/src/uds/diagnostic_session_control/include/DiagnosticSessionControl.h
+++ b/src/uds/diagnostic_session_control/include/DiagnosticSessionControl.h
@@ -17,18 +17,15 @@
 #define DIAGNOSTICSESSIONCONTROL_H
 
 #include <cstdlib>
+#include <iostream>
 #include "../../../utils/include/GenerateFrames.h"
 #include "../../../utils/include/Logger.h"
+#include "../../../utils/include/NegativeResponse.h"
+
 /* Diagnostic Control Session codes */
 const uint8_t SID_DIAGNOSTIC_SESSION_CONTROL = 0x10;
 const uint8_t SUB_FUNCTION_DEFAULT_SESSION = 1;
 const uint8_t SUB_FUNCTION_PROGRAMMING_SESSION = 2;
-
-/* Negative response codes */
-const uint8_t NR_SUBFUNCION_NOT_SUPPORTED = 0x12;
-const uint8_t NR_INCORRECT_MESSAGE_LENGTH = 0x13;
-const uint8_t NR_AUTHENTICATION_FAILED = 0x34;
-const uint8_t NR_RESOURCE_TEMP_UNAVAILABLE = 0x94;
 
 enum DiagnosticSession
 {

--- a/src/uds/ecu_reset/src/EcuReset.cpp
+++ b/src/uds/ecu_reset/src/EcuReset.cpp
@@ -157,6 +157,35 @@ void EcuReset::ecuResetResponse()
     can_id = (frame_sender_id << 8) | frame_dest_id;
     LOG_INFO(ECUResetLog.GET_LOGGER(), "can_id = 0x{0:x}", can_id);
 
-    generate_frames.ecuReset(can_id, sub_function, generate_frames.getSocket(), true);
-    LOG_INFO(ECUResetLog.GET_LOGGER(), "Response sent");
+    switch(frame_dest_id)
+    {
+        case 0x10:
+            if (MCU::mcu->stop_flags.find(0x11) != MCU::mcu->stop_flags.end())
+            {
+                /* Send response frame */
+                generate_frames.ecuReset(can_id, sub_function, generate_frames.getSocket(), true);
+                LOG_INFO(ECUResetLog.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x11);
+            } else
+            {
+                LOG_INFO(ECUResetLog.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x11);
+                NegativeResponse negative_response(response_socket, ECUResetLog);
+                negative_response.sendNRC(can_id, 0x11, 0x78);
+            }
+            break;
+        case 0x11:
+            if (battery->stop_flags.find(0x11) != battery->stop_flags.end())
+            {
+                /* Send response frame */
+                generate_frames.ecuReset(can_id, sub_function, generate_frames.getSocket(), true);
+                LOG_INFO(ECUResetLog.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x11);
+            } else
+            {
+                LOG_INFO(ECUResetLog.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x11);
+                NegativeResponse negative_response(response_socket, ECUResetLog);
+                negative_response.sendNRC(can_id, 0x11, 0x78);
+            }
+            break;
+        default:
+            LOG_ERROR(ECUResetLog.GET_LOGGER(), "Module with id {:x} not supported.", frame_dest_id);
+    }
 }

--- a/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
+++ b/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
@@ -77,10 +77,73 @@ std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, 
     }
 
     if (use_send_frame) {
-        if (response.size() > 7) {
-            generate_frames.readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
-        } else {
-            generate_frames.readDataByIdentifier(can_id, data_identifier, response);
+        if (response.size() > 7)
+        {
+            switch(lowerbits)
+            {
+                case 0x10:
+                    if (MCU::mcu->stop_flags.find(0x22) != MCU::mcu->stop_flags.end())
+                    {
+                        /* Send response frame */
+                        generate_frames.readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
+                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
+                    } else
+                    {
+                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x22);
+                        NegativeResponse negative_response(socket, rdbi_logger);
+                        negative_response.sendNRC(can_id, 0x22, 0x78);
+                    }
+                    break;
+                case 0x11:
+                    if (battery->stop_flags.find(0x22) != battery->stop_flags.end())
+                    {
+                        /* Send response frame */
+                        generate_frames.readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
+                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
+                    } else
+                    {
+                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x22);
+                        NegativeResponse negative_response(socket, rdbi_logger);
+                        negative_response.sendNRC(can_id, 0x22, 0x78);
+                    }
+                    break;
+                default:
+                    LOG_ERROR(rdbi_logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
+            }
+        } 
+        else
+        {   
+            switch(lowerbits)
+            {
+                case 0x10:
+                    if (MCU::mcu->stop_flags.find(0x22) != MCU::mcu->stop_flags.end())
+                    {
+                        /* Send response frame */
+                        generate_frames.readDataByIdentifier(can_id, data_identifier, response);
+                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
+                    } else
+                    {
+                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x22);
+                        NegativeResponse negative_response(socket, rdbi_logger);
+                        negative_response.sendNRC(can_id, 0x22, 0x78);
+                    }
+                    break;
+                case 0x11:
+                    if (battery->stop_flags.find(0x22) != battery->stop_flags.end())
+                    {
+                        /* Send response frame */
+                        generate_frames.readDataByIdentifier(can_id, data_identifier, response);
+                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
+                    } else
+                    {
+                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x22);
+                        NegativeResponse negative_response(socket, rdbi_logger);
+                        negative_response.sendNRC(can_id, 0x22, 0x78);
+                    }
+                    break;
+                default:
+                    LOG_ERROR(rdbi_logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
+            }
         }
     }
     return response;

--- a/src/uds/routine_control/src/RoutineControl.cpp
+++ b/src/uds/routine_control/src/RoutineControl.cpp
@@ -1,4 +1,6 @@
 #include "../include/RoutineControl.h"
+#include "../../../ecu_simulation/BatteryModule/include/BatteryModule.h"
+#include "../../../mcu/include/MCUModule.h"
 
 RoutineControl::RoutineControl(int socket, Logger& rc_logger) 
             : generate_frames(socket, rc_logger), rc_logger(rc_logger)
@@ -46,14 +48,72 @@ void RoutineControl::routineControl(canid_t can_id, const std::vector<uint8_t>& 
             case 0x0101:
                 /* Erase memory or specific data */
                 /* call eraseMemory routine */
-                generate_frames.routineControl(can_id, request[2], routine_identifier, true);
-                LOG_INFO(rc_logger.GET_LOGGER(), "eraseMemory routine called.");
+                switch(lowerbits)
+                {
+                    case 0x10:
+                        if (MCU::mcu->stop_flags.find(0x31) != MCU::mcu->stop_flags.end())
+                        {
+                            /* Send response frame */
+                            generate_frames.routineControl(can_id, request[2], routine_identifier, true);
+                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame: eraseMemory routine.", 0x31);
+                        } else
+                        {
+                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x31);
+                            NegativeResponse negative_response(socket, rc_logger);
+                            negative_response.sendNRC(can_id, 0x31, 0x78);
+                        }
+                        break;
+                    case 0x11:
+                        if (battery->stop_flags.find(0x31) != battery->stop_flags.end())
+                        {
+                            /* Send response frame */
+                            generate_frames.routineControl(can_id, request[2], routine_identifier, true);
+                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame: eraseMemory routine.", 0x31);
+                        } else
+                        {
+                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x31);
+                            NegativeResponse negative_response(socket, rc_logger);
+                            negative_response.sendNRC(can_id, 0x31, 0x78);
+                        }
+                        break;
+                    default:
+                        LOG_ERROR(rc_logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
+                }
                 break;
             case 0x0201:
                 /* Install updates */
                 /* call installUpdates routine*/
-                generate_frames.routineControl(can_id, request[2], routine_identifier, true);
-                LOG_INFO(rc_logger.GET_LOGGER(), "installUpdates routine called.");
+                switch(lowerbits)
+                {
+                    case 0x10:
+                        if (MCU::mcu->stop_flags.find(0x31) != MCU::mcu->stop_flags.end())
+                        {
+                            /* Send response frame */
+                            generate_frames.routineControl(can_id, request[2], routine_identifier, true);
+                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame: installUpdates routine.", 0x31);
+                        } else
+                        {
+                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x31);
+                            NegativeResponse negative_response(socket, rc_logger);
+                            negative_response.sendNRC(can_id, 0x31, 0x78);
+                        }
+                        break;
+                    case 0x11:
+                        if (battery->stop_flags.find(0x31) != battery->stop_flags.end())
+                        {
+                            /* Send response frame */
+                            generate_frames.routineControl(can_id, request[2], routine_identifier, true);
+                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame: installUpdates routine.", 0x31);
+                        } else
+                        {
+                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x31);
+                            NegativeResponse negative_response(socket, rc_logger);
+                            negative_response.sendNRC(can_id, 0x31, 0x78);
+                        }
+                        break;
+                    default:
+                        LOG_ERROR(rc_logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
+                }
                 break;
             default:
                 LOG_INFO(rc_logger.GET_LOGGER(), "Unknown routine.");

--- a/src/uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp
+++ b/src/uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp
@@ -104,7 +104,36 @@ void WriteDataByIdentifier::WriteDataByIdentifierService(canid_t frame_id, std::
             nrc.sendNRC(id,WDBI_SID,NegativeResponse::ROOR);
         }
 
-        /* Check on which socket to send the frame */
-        generate_frames.writeDataByIdentifier(id, did, {});
+        switch(receiver_id)
+        {
+            case 0x10:
+                if (MCU::mcu->stop_flags.find(0x2E) != MCU::mcu->stop_flags.end())
+                {
+                    /* Send response frame */
+                    generate_frames.writeDataByIdentifier(id, did, {});
+                    LOG_INFO(wdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x2E);
+                } else
+                {
+                    LOG_INFO(wdbi_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x2E);
+                    NegativeResponse negative_response(socket, wdbi_logger);
+                    negative_response.sendNRC(id, 0x2E, 0x78);
+                }
+                break;
+            case 0x11:
+                if (battery->stop_flags.find(0x2E) != battery->stop_flags.end())
+                {
+                    /* Send response frame */
+                    generate_frames.writeDataByIdentifier(id, did, {});
+                    LOG_INFO(wdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x2E);
+                } else
+                {
+                    LOG_INFO(wdbi_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x2E);
+                    NegativeResponse negative_response(socket, wdbi_logger);
+                    negative_response.sendNRC(id, 0x2E, 0x78);
+                }
+                break;
+            default:
+                LOG_ERROR(wdbi_logger.GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);
+        }
     }
 };

--- a/src/utils/include/NegativeResponse.h
+++ b/src/utils/include/NegativeResponse.h
@@ -57,21 +57,25 @@ class NegativeResponse
         static constexpr uint8_t GPF = 0x72;
         /* Wrong Block Sequence Counter */
         static constexpr uint8_t WBSC = 0x73;
+        /* Request Correctly Received-Response Pending */
+        static constexpr uint8_t RCR_RP = 0x78;
+        /* SubFunction Not Supported In Active Session */
+        static constexpr uint8_t SFNSIAS = 0x7E;
+        /* Function Not Supported In Active Session */
+        static constexpr uint8_t FNSIAS = 0x7F;
         /* Voltage Too High */
         static constexpr uint8_t VTH = 0x92;
         /* Voltage Too Low */
         static constexpr uint8_t VTL = 0x93;
 
+        NegativeResponse(int socket, Logger& nrc_logger);
+        std::string getDescription(uint8_t code);
+        void sendNRC(int id, uint8_t sid, uint8_t nrc);
+
     private:
         GenerateFrames* generate_frames;
         Logger& nrc_logger;
         int socket = -1;
-
-    public:
-        NegativeResponse(int socket, Logger& nrc_logger);
-        std::string getDescription(uint8_t code);
-        void sendNRC(int id, uint8_t sid, uint8_t nrc);
- 
 };
 
 #endif

--- a/src/utils/src/NegativeResponse.cpp
+++ b/src/utils/src/NegativeResponse.cpp
@@ -19,7 +19,10 @@ const std::map<uint8_t, std::string> NegativeResponse::nrcMap =
     {GPF, "General Programming Failure"},
     {WBSC, "Wrong Block Sequence Counter"},
     {VTH, "Voltage Too High"},
-    {VTL, "Voltage Too Low"}
+    {VTL, "Voltage Too Low"},
+    {RCR_RP, "Request Correctly Received-Response Pending"},
+    {SFNSIAS, "SubFunction Not Supported In Active Session"},
+    {FNSIAS, "Function Not Supported In Active Session"}
 };
 
 NegativeResponse::NegativeResponse(int socket, Logger& nrc_logger)


### PR DESCRIPTION
I integrated the DiagnosticSessionControl and AccessTimingParameter services into the MCU and Battery modules. Added functionality to time each frame's processing. If processing time exceeds ATP thresholds, an NRC is thrown; otherwise, the response is sent.

## Trello link [here](https://trello.com/c/yDxJwrbq/27-integrate-dsc-atp-services)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
