### PR TITLE
Updates to AccessTimingParameter integration logic

### DIFF
--- a/src/ecu_simulation/BatteryModule/include/ReceiveFrames.h
+++ b/src/ecu_simulation/BatteryModule/include/ReceiveFrames.h
@@ -31,27 +31,81 @@
 #include <atomic>
 #include <poll.h> 
 #include <future>
+#include <set>
+
 #include "../include/HandleFrames.h"
 #include "../include/GenerateFrames.h"
 #include "../include/BatteryModuleLogger.h"
 
-  /* List of service we have implemented. */
-  const std::vector<uint8_t> service_sids = {
-    0x11, // ECU Reset
-    0x10, // Diagnostic Session Control
-    0x22, // Read Data By Identifier
-    0x29, // Authentication
-    0x31, // Routine Control (Testing) -> will be decided
-    0x3E, // Tester Present
-    0x23, // Read Memory By Address
-    0x2E, // Write Data By Identifier
-    0x19, // Read DTC Information
-    0x14, // Clear Diagnostic Information
-    0x83, // Access Timing Parameters
-    0x34, // Request Download
-    0x36, // Transfer Data
-    0x37, // Request Transfer Exit
-    0x32  // Request update status
+/* List of service we have implemented. */
+const std::vector<uint8_t> service_sids = {
+    /* ECU Reset */
+    0x11,
+    /* Diagnostic Session Control */
+    0x10,
+    /* Read Data By Identifier */
+    0x22,
+    /* Authentication */
+    0x29,
+    /* Routine Control (Testing) -> will be decided */
+    0x31,
+    /* Tester Present */
+    0x3E,
+    /* Read Memory By Address */
+    0x23,
+    /* Write Data By Identifier */
+    0x2E,
+    /* Read DTC Information */
+    0x19,
+    /* Clear Diagnostic Information */
+    0x14,
+    /* Access Timing Parameters */
+    0x83,
+    /* Request Download */
+    0x34,
+    /* Transfer Data */
+    0x36,
+    /* Request Transfer Exit */
+    0x37,
+    /* Request update status */
+    0x32
+};
+
+/* Define lists of SIDs using p2_max_time and p2_star_max_time */
+static const std::set<uint8_t> sids_using_p2_max_time = {
+    /* ECU Reset */
+    0x11,
+    /* Diagnostic Session Control */
+    0x10,
+    /* Read Data By Identifier */
+    0x22,
+    /* Tester Present */
+    0x3E,
+    /* Read Memory By Address */
+    0x23,
+    /* Write Data By Identifier */
+    0x2E,
+    /* Read DTC Information */
+    0x19,
+    /* Clear Diagnostic Information */
+    0x14,
+    /* Access Timing Parameters */
+    0x83,
+    /* Request update status */
+    0x32
+};
+
+static const std::set<uint8_t> sids_using_p2_star_max_time = {
+    /* Routine Control */
+    0x31,
+    /* Request Download */
+    0x34,
+    /* Transfer Data */
+    0x36,
+    /* Request Transfer Exit */
+    0x37,
+    /* Authentication */
+    0x29
 };
 
 class ReceiveFrames 

--- a/src/mcu/include/ReceiveFrames.h
+++ b/src/mcu/include/ReceiveFrames.h
@@ -52,6 +52,7 @@
 #include<thread>
 #include <future>
 #include <atomic>
+#include <set>
 
 #include "../include/HandleFrames.h"
 #include "../../utils/include/GenerateFrames.h"
@@ -61,22 +62,74 @@ namespace MCU
 {
   /* List of service we have implemented. */
   const std::vector<uint8_t> service_sids = {
-    0x11, // ECU Reset
-    0x10, // Diagnostic Session Control
-    0x22, // Read Data By Identifier
-    0x29, // Authentication
-    0x31, // Routine Control (Testing) -> will be decided
-    0x3E, // Tester Present
-    0x23, // Read Memory By Address
-    0x2E, // Write Data By Identifier
-    0x19, // Read DTC Information
-    0x14, // Clear Diagnostic Information
-    0x83, // Access Timing Parameters
-    0x34, // Request Download
-    0x36, // Transfer Data
-    0x37, // Request Transfer Exit
-    0x32  // Request update status
-};
+      /* ECU Reset */
+      0x11,
+      /* Diagnostic Session Control */
+      0x10,
+      /* Read Data By Identifier */
+      0x22,
+      /* Authentication */
+      0x29,
+      /* Routine Control (Testing) -> will be decided */
+      0x31,
+      /* Tester Present */
+      0x3E,
+      /* Read Memory By Address */
+      0x23,
+      /* Write Data By Identifier */
+      0x2E,
+      /* Read DTC Information */
+      0x19,
+      /* Clear Diagnostic Information */
+      0x14,
+      /* Access Timing Parameters */
+      0x83,
+      /* Request Download */
+      0x34,
+      /* Transfer Data */
+      0x36,
+      /* Request Transfer Exit */
+      0x37,
+      /* Request update status */
+      0x32
+  };
+
+  /* Define lists of SIDs using p2_max_time and p2_star_max_time */
+  static const std::set<uint8_t> sids_using_p2_max_time = {
+      /* ECU Reset */
+      0x11,
+      /* Diagnostic Session Control */
+      0x10,
+      /* Read Data By Identifier */
+      0x22,
+      /* Tester Present */
+      0x3E,
+      /* Read Memory By Address */
+      0x23,
+      /* Write Data By Identifier */
+      0x2E,
+      /* Read DTC Information */
+      0x19,
+      /* Clear Diagnostic Information */
+      0x14,
+      /* Access Timing Parameters */
+      0x83,
+      /* Request update status */
+      0x32
+  };
+
+  static const std::set<uint8_t> sids_using_p2_star_max_time = {
+      /* Routine Control */
+      0x31,
+      /* Request Download */
+      0x34,
+      /* Transfer Data */
+      0x36,
+      /* Request Transfer Exit */
+      0x37,
+      /* Authentication */
+      0x29
+  };
 
   class ReceiveFrames
   {

--- a/src/uds/access_timing_parameters/src/AccessTimingParameter.cpp
+++ b/src/uds/access_timing_parameters/src/AccessTimingParameter.cpp
@@ -258,30 +258,16 @@ void AccessTimingParameter::setTimingParameters(canid_t frame_id, std::vector<ui
     switch(receiver_id)
         {
             case 0x10:
-                if (MCU::mcu->stop_flags.find(0x83) != MCU::mcu->stop_flags.end())
-                {
-                    /* Send response frame */
-                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x83);
-                    response_frame.accessTimingParameters(id, 0x04, response, true);
-                } else
-                {
-                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x83);
-                    NegativeResponse negative_response(socket, atp_logger);
-                    negative_response.sendNRC(id, 0x83, 0x78);
-                }
+                /* Send response frame */
+                LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x83);
+                response_frame.accessTimingParameters(id, 0x04, response, true);
+                MCU::mcu->stop_flags[0x83] = false;
                 break;
             case 0x11:
-                if (battery->stop_flags.find(0x83) != battery->stop_flags.end())
-                {
-                    /* Send response frame */
-                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x83);
-                    response_frame.accessTimingParameters(id, 0x04, response, true);
-                } else
-                {
-                    LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x83);
-                    NegativeResponse negative_response(socket, atp_logger);
-                    negative_response.sendNRC(id, 0x83, 0x78);
-                }
+                /* Send response frame */
+                LOG_INFO(atp_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x83);
+                response_frame.accessTimingParameters(id, 0x04, response, true);
+                battery->stop_flags[0x83] = false;
                 break;
             default:
                 LOG_ERROR(atp_logger.GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);

--- a/src/uds/clear_dtc/src/ClearDtc.cpp
+++ b/src/uds/clear_dtc/src/ClearDtc.cpp
@@ -47,30 +47,16 @@ void ClearDtc::clearDtc(int id, std::vector<uint8_t> data)
         switch(lowerbits)
         {
             case 0x10:
-                if (MCU::mcu->stop_flags.find(0x14) != MCU::mcu->stop_flags.end())
-                {
-                    /* Send response frame */
-                    this->generate->clearDiagnosticInformation(new_id,{}, true);
-                    LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x14);
-                } else
-                {
-                    LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x14);
-                    NegativeResponse negative_response(socket, *logger);
-                    negative_response.sendNRC(id, 0x14, 0x78);
-                }
+                /* Send response frame */
+                this->generate->clearDiagnosticInformation(new_id,{}, true);
+                LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x14);
+                MCU::mcu->stop_flags[0x14] = false;
                 break;
             case 0x11:
-                if (battery->stop_flags.find(0x14) != battery->stop_flags.end())
-                {
-                    /* Send response frame */
-                    this->generate->clearDiagnosticInformation(new_id,{}, true);
-                    LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x14);
-                } else
-                {
-                    LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x14);
-                    NegativeResponse negative_response(socket, *logger);
-                    negative_response.sendNRC(id, 0x14, 0x78);
-                }
+                /* Send response frame */
+                this->generate->clearDiagnosticInformation(new_id,{}, true);
+                LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x14);
+                battery->stop_flags[0x14] = false;
                 break;
             default:
                 LOG_ERROR(logger->GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
@@ -111,30 +97,16 @@ void ClearDtc::clearDtc(int id, std::vector<uint8_t> data)
     switch(lowerbits)
     {
         case 0x10:
-            if (MCU::mcu->stop_flags.find(0x14) != MCU::mcu->stop_flags.end())
-            {
-                /* Send response frame */
-                LOG_INFO(logger->GET_LOGGER(), "DTCs cleared succesffuly");
-                this->generate->clearDiagnosticInformation(new_id,{}, true);
-            } else
-            {
-                LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x14);
-                NegativeResponse negative_response(socket, *logger);
-                negative_response.sendNRC(id, 0x14, 0x78);
-            }
+            /* Send response frame */
+            LOG_INFO(logger->GET_LOGGER(), "DTCs cleared succesffuly");
+            this->generate->clearDiagnosticInformation(new_id,{}, true);
+            MCU::mcu->stop_flags[0x14] = false;
             break;
         case 0x11:
-            if (battery->stop_flags.find(0x14) != battery->stop_flags.end())
-            {
-                /* Send response frame */
-                LOG_INFO(logger->GET_LOGGER(), "DTCs cleared succesffuly");
-                this->generate->clearDiagnosticInformation(new_id,{}, true);
-            } else
-            {
-                LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x14);
-                NegativeResponse negative_response(socket, *logger);
-                negative_response.sendNRC(id, 0x14, 0x78);
-            }
+            /* Send response frame */
+            LOG_INFO(logger->GET_LOGGER(), "DTCs cleared succesffuly");
+            this->generate->clearDiagnosticInformation(new_id,{}, true);
+            battery->stop_flags[0x14] = false;
             break;
         default:
             LOG_ERROR(logger->GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);

--- a/src/uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp
+++ b/src/uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp
@@ -69,30 +69,16 @@ void DiagnosticSessionControl::switchToDefaultSession(canid_t frame_id)
     switch(receiver_id)
     {
         case 0x10:
-            if (MCU::mcu->stop_flags.find(0x10) != MCU::mcu->stop_flags.end())
-            {
-                /* Send response frame */
-                response_frame.sessionControl(id, 0x01, true);
-                LOG_INFO(dsc_logger->GET_LOGGER(), "Sent pozitive response");
-            } else
-            {
-                LOG_INFO(dsc_logger->GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x10);
-                NegativeResponse negative_response(socket, *dsc_logger);
-                negative_response.sendNRC(id, 0x10, 0x78);
-            }
+            /* Send response frame */
+            response_frame.sessionControl(id, 0x01, true);
+            LOG_INFO(dsc_logger->GET_LOGGER(), "Sent pozitive response");
+            MCU::mcu->stop_flags[0x10] = false;
             break;
         case 0x11:
-            if (battery->stop_flags.find(0x10) != battery->stop_flags.end())
-            {
-                /* Send response frame */
-                response_frame.sessionControl(id, 0x01, true);
-                LOG_INFO(dsc_logger->GET_LOGGER(), "Sent pozitive response");
-            } else
-            {
-                LOG_INFO(dsc_logger->GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x10);
-                NegativeResponse negative_response(socket, *dsc_logger);
-                negative_response.sendNRC(id, 0x10, 0x78);
-            }
+            /* Send response frame */
+            response_frame.sessionControl(id, 0x01, true);
+            LOG_INFO(dsc_logger->GET_LOGGER(), "Sent pozitive response");
+            battery->stop_flags[0x10] = false;
             break;
         default:
             LOG_ERROR(dsc_logger->GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);
@@ -117,34 +103,20 @@ void DiagnosticSessionControl::switchToProgrammingSession(canid_t frame_id)
     switch(receiver_id)
     {
         case 0x10:
-            if (MCU::mcu->stop_flags.find(0x10) != MCU::mcu->stop_flags.end())
-            {
-                /* Send response frame */
-                response_frame.sessionControl(id, 0x02, true);
-                LOG_INFO(dsc_logger->GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x10);
-            } else
-            {
-                LOG_INFO(dsc_logger->GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x10);
-                NegativeResponse negative_response(socket, *dsc_logger);
-                negative_response.sendNRC(id, 0x10, 0x78);
-            }
+            /* Send response frame */
+            response_frame.sessionControl(id, 0x02, true);
+            LOG_INFO(dsc_logger->GET_LOGGER(), "Sent pozitive response");
+            MCU::mcu->stop_flags[0x10] = false;
             break;
         case 0x11:
-            if (battery->stop_flags.find(0x10) != battery->stop_flags.end())
-            {
-                /* Send response frame */
-                response_frame.sessionControl(id, 0x02, true);
-                LOG_INFO(dsc_logger->GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x10);
-            } else
-            {
-                LOG_INFO(dsc_logger->GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x10);
-                NegativeResponse negative_response(socket, *dsc_logger);
-                negative_response.sendNRC(id, 0x10, 0x78);
-            }
+            /* Send response frame */
+            response_frame.sessionControl(id, 0x02, true);
+            LOG_INFO(dsc_logger->GET_LOGGER(), "Sent pozitive response");
+            battery->stop_flags[0x10] = false;
             break;
         default:
             LOG_ERROR(dsc_logger->GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);
-    }
+    } 
 }
 
 /* Method to get the current session of module */

--- a/src/uds/ecu_reset/src/EcuReset.cpp
+++ b/src/uds/ecu_reset/src/EcuReset.cpp
@@ -160,30 +160,16 @@ void EcuReset::ecuResetResponse()
     switch(frame_dest_id)
     {
         case 0x10:
-            if (MCU::mcu->stop_flags.find(0x11) != MCU::mcu->stop_flags.end())
-            {
-                /* Send response frame */
-                generate_frames.ecuReset(can_id, sub_function, generate_frames.getSocket(), true);
-                LOG_INFO(ECUResetLog.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x11);
-            } else
-            {
-                LOG_INFO(ECUResetLog.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x11);
-                NegativeResponse negative_response(response_socket, ECUResetLog);
-                negative_response.sendNRC(can_id, 0x11, 0x78);
-            }
+            /* Send response frame */
+            generate_frames.ecuReset(can_id, sub_function, generate_frames.getSocket(), true);
+            LOG_INFO(ECUResetLog.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x11);
+            MCU::mcu->stop_flags[0x11] = false;
             break;
         case 0x11:
-            if (battery->stop_flags.find(0x11) != battery->stop_flags.end())
-            {
-                /* Send response frame */
-                generate_frames.ecuReset(can_id, sub_function, generate_frames.getSocket(), true);
-                LOG_INFO(ECUResetLog.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x11);
-            } else
-            {
-                LOG_INFO(ECUResetLog.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x11);
-                NegativeResponse negative_response(response_socket, ECUResetLog);
-                negative_response.sendNRC(can_id, 0x11, 0x78);
-            }
+            /* Send response frame */
+            generate_frames.ecuReset(can_id, sub_function, generate_frames.getSocket(), true);
+            LOG_INFO(ECUResetLog.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x11);
+            battery->stop_flags[0x11] = false;
             break;
         default:
             LOG_ERROR(ECUResetLog.GET_LOGGER(), "Module with id {:x} not supported.", frame_dest_id);

--- a/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
+++ b/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
@@ -82,30 +82,16 @@ std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, 
             switch(lowerbits)
             {
                 case 0x10:
-                    if (MCU::mcu->stop_flags.find(0x22) != MCU::mcu->stop_flags.end())
-                    {
-                        /* Send response frame */
-                        generate_frames.readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
-                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
-                    } else
-                    {
-                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x22);
-                        NegativeResponse negative_response(socket, rdbi_logger);
-                        negative_response.sendNRC(can_id, 0x22, 0x78);
-                    }
+                    /* Send response frame */
+                    generate_frames.readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
+                    LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
+                    MCU::mcu->stop_flags[0x22] = false;
                     break;
                 case 0x11:
-                    if (battery->stop_flags.find(0x22) != battery->stop_flags.end())
-                    {
-                        /* Send response frame */
-                        generate_frames.readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
-                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
-                    } else
-                    {
-                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x22);
-                        NegativeResponse negative_response(socket, rdbi_logger);
-                        negative_response.sendNRC(can_id, 0x22, 0x78);
-                    }
+                    /* Send response frame */
+                    generate_frames.readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
+                    LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
+                    battery->stop_flags[0x22] = false;
                     break;
                 default:
                     LOG_ERROR(rdbi_logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
@@ -116,30 +102,16 @@ std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, 
             switch(lowerbits)
             {
                 case 0x10:
-                    if (MCU::mcu->stop_flags.find(0x22) != MCU::mcu->stop_flags.end())
-                    {
-                        /* Send response frame */
-                        generate_frames.readDataByIdentifier(can_id, data_identifier, response);
-                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
-                    } else
-                    {
-                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x22);
-                        NegativeResponse negative_response(socket, rdbi_logger);
-                        negative_response.sendNRC(can_id, 0x22, 0x78);
-                    }
+                    /* Send response frame */
+                    generate_frames.readDataByIdentifier(can_id, data_identifier, response);
+                    LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
+                    MCU::mcu->stop_flags[0x22] = false;
                     break;
                 case 0x11:
-                    if (battery->stop_flags.find(0x22) != battery->stop_flags.end())
-                    {
-                        /* Send response frame */
-                        generate_frames.readDataByIdentifier(can_id, data_identifier, response);
-                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
-                    } else
-                    {
-                        LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x22);
-                        NegativeResponse negative_response(socket, rdbi_logger);
-                        negative_response.sendNRC(can_id, 0x22, 0x78);
-                    }
+                    /* Send response frame */
+                    generate_frames.readDataByIdentifier(can_id, data_identifier, response);
+                    LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
+                    battery->stop_flags[0x22] = false;
                     break;
                 default:
                     LOG_ERROR(rdbi_logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);

--- a/src/uds/read_dtc_information/src/ReadDtcInformation.cpp
+++ b/src/uds/read_dtc_information/src/ReadDtcInformation.cpp
@@ -89,30 +89,16 @@ void ReadDTC::number_of_dtc(int id, int dtc_status_mask)
     switch(lowerbits)
     {
         case 0x10:
-            if (MCU::mcu->stop_flags.find(0x19) != MCU::mcu->stop_flags.end())
-            {
-                /* Send response frame */
-                this->generate->readDtcInformationResponse01(id,status_availability_mask,dtc_format_identifier,number_of_dtc);
-                LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x19);
-            } else
-            {
-                LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x19);
-                NegativeResponse negative_response(socket, logger);
-                negative_response.sendNRC(id, 0x19, 0x78);
-            }
+            /* Send response frame */
+            this->generate->readDtcInformationResponse01(id,status_availability_mask,dtc_format_identifier,number_of_dtc);
+            LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x19);
+            MCU::mcu->stop_flags[0x19] = false;
             break;
         case 0x11:
-            if (battery->stop_flags.find(0x19) != battery->stop_flags.end())
-            {
-                /* Send response frame */
-                this->generate->readDtcInformationResponse01(id,status_availability_mask,dtc_format_identifier,number_of_dtc);
-                LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x19);
-            } else
-            {
-                LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x19);
-                NegativeResponse negative_response(socket, logger);
-                negative_response.sendNRC(id, 0x19, 0x78);
-            }
+            /* Send response frame */
+            this->generate->readDtcInformationResponse01(id,status_availability_mask,dtc_format_identifier,number_of_dtc);
+            LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x19);
+            battery->stop_flags[0x19] = false;
             break;
         default:
             LOG_ERROR(logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
@@ -162,30 +148,16 @@ void ReadDTC::report_dtcs(int id, int dtc_status_mask)
         switch(lowerbits)
         {
             case 0x10:
-                if (MCU::mcu->stop_flags.find(0x19) != MCU::mcu->stop_flags.end())
-                {
-                    /* Send response frame */
-                    this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,true);
-                    LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the first response frame.", 0x19);
-                } else
-                {
-                    LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x19);
-                    NegativeResponse negative_response(socket, logger);
-                    negative_response.sendNRC(id, 0x19, 0x78);
-                }
+                /* Send response frame */
+                this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,true);
+                LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the first response frame.", 0x19);
+                MCU::mcu->stop_flags[0x19] = false;
                 break;
             case 0x11:
-                if (battery->stop_flags.find(0x19) != battery->stop_flags.end())
-                {
-                    /* Send response frame */
-                    this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,true);
-                    LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the first response frame.", 0x19);
-                } else
-                {
-                    LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x19);
-                    NegativeResponse negative_response(socket, logger);
-                    negative_response.sendNRC(id, 0x19, 0x78);
-                }
+                /* Send response frame */
+                this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,true);
+                LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the first response frame.", 0x19);
+                battery->stop_flags[0x19] = false;
                 break;
             default:
                 LOG_ERROR(logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
@@ -197,30 +169,16 @@ void ReadDTC::report_dtcs(int id, int dtc_status_mask)
             switch(lowerbits)
             {
                 case 0x10:
-                    if (MCU::mcu->stop_flags.find(0x19) != MCU::mcu->stop_flags.end())
-                    {
-                        /* Send response frame */
-                        this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,false);
-                        LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent a consecutive response frame.", 0x19);
-                    } else
-                    {
-                        LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x19);
-                        NegativeResponse negative_response(socket, logger);
-                        negative_response.sendNRC(id, 0x19, 0x78);
-                    }
+                    /* Send response frame */
+                    this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,false);
+                    LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent a consecutive response frame.", 0x19);
+                    MCU::mcu->stop_flags[0x19] = false;
                     break;
                 case 0x11:
-                    if (battery->stop_flags.find(0x19) != battery->stop_flags.end())
-                    {
-                        /* Send response frame */
-                        this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,false);
-                        LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent a consecutive response frame.", 0x19);
-                    } else
-                    {
-                        LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x19);
-                        NegativeResponse negative_response(socket, logger);
-                        negative_response.sendNRC(id, 0x19, 0x78);
-                    }
+                    /* Send response frame */
+                    this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,false);
+                    LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent a consecutive response frame.", 0x19);
+                    battery->stop_flags[0x19] = false;
                     break;
                 default:
                     LOG_ERROR(logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
@@ -238,30 +196,16 @@ void ReadDTC::report_dtcs(int id, int dtc_status_mask)
         switch(lowerbits)
         {
             case 0x10:
-                if (MCU::mcu->stop_flags.find(0x19) != MCU::mcu->stop_flags.end())
-                {
-                    /* Send response frame */
-                    this->generate->readDtcInformationResponse02(id,status_availability_mask,dtc_and_status_list);
-                    LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the first response frame.", 0x19);
-                } else
-                {
-                    LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x19);
-                    NegativeResponse negative_response(socket, logger);
-                    negative_response.sendNRC(id, 0x19, 0x78);
-                }
+                /* Send response frame */
+                this->generate->readDtcInformationResponse02(id,status_availability_mask,dtc_and_status_list);
+                LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the first response frame.", 0x19);
+                MCU::mcu->stop_flags[0x19] = false;
                 break;
             case 0x11:
-                if (battery->stop_flags.find(0x19) != battery->stop_flags.end())
-                {
-                    /* Send response frame */
-                    this->generate->readDtcInformationResponse02(id,status_availability_mask,dtc_and_status_list);
-                    LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the first response frame.", 0x19);
-                } else
-                {
-                    LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x19);
-                    NegativeResponse negative_response(socket, logger);
-                    negative_response.sendNRC(id, 0x19, 0x78);
-                }
+                /* Send response frame */
+                this->generate->readDtcInformationResponse02(id,status_availability_mask,dtc_and_status_list);
+                LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the first response frame.", 0x19);
+                battery->stop_flags[0x19] = false;
                 break;
             default:
                 LOG_ERROR(logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);

--- a/src/uds/routine_control/src/RoutineControl.cpp
+++ b/src/uds/routine_control/src/RoutineControl.cpp
@@ -51,30 +51,16 @@ void RoutineControl::routineControl(canid_t can_id, const std::vector<uint8_t>& 
                 switch(lowerbits)
                 {
                     case 0x10:
-                        if (MCU::mcu->stop_flags.find(0x31) != MCU::mcu->stop_flags.end())
-                        {
-                            /* Send response frame */
-                            generate_frames.routineControl(can_id, request[2], routine_identifier, true);
-                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame: eraseMemory routine.", 0x31);
-                        } else
-                        {
-                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x31);
-                            NegativeResponse negative_response(socket, rc_logger);
-                            negative_response.sendNRC(can_id, 0x31, 0x78);
-                        }
+                        /* Send response frame */
+                        generate_frames.routineControl(can_id, request[2], routine_identifier, true);
+                        LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame: eraseMemory routine.", 0x31);
+                        MCU::mcu->stop_flags[0x31] = false;
                         break;
                     case 0x11:
-                        if (battery->stop_flags.find(0x31) != battery->stop_flags.end())
-                        {
-                            /* Send response frame */
-                            generate_frames.routineControl(can_id, request[2], routine_identifier, true);
-                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame: eraseMemory routine.", 0x31);
-                        } else
-                        {
-                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x31);
-                            NegativeResponse negative_response(socket, rc_logger);
-                            negative_response.sendNRC(can_id, 0x31, 0x78);
-                        }
+                        /* Send response frame */
+                        generate_frames.routineControl(can_id, request[2], routine_identifier, true);
+                        LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame: eraseMemory routine.", 0x31);
+                        battery->stop_flags[0x31] = false;
                         break;
                     default:
                         LOG_ERROR(rc_logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
@@ -86,30 +72,16 @@ void RoutineControl::routineControl(canid_t can_id, const std::vector<uint8_t>& 
                 switch(lowerbits)
                 {
                     case 0x10:
-                        if (MCU::mcu->stop_flags.find(0x31) != MCU::mcu->stop_flags.end())
-                        {
-                            /* Send response frame */
-                            generate_frames.routineControl(can_id, request[2], routine_identifier, true);
-                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame: installUpdates routine.", 0x31);
-                        } else
-                        {
-                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x31);
-                            NegativeResponse negative_response(socket, rc_logger);
-                            negative_response.sendNRC(can_id, 0x31, 0x78);
-                        }
+                        /* Send response frame */
+                        generate_frames.routineControl(can_id, request[2], routine_identifier, true);
+                        LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame: installUpdates routine.", 0x31);
+                        MCU::mcu->stop_flags[0x31] = false;
                         break;
                     case 0x11:
-                        if (battery->stop_flags.find(0x31) != battery->stop_flags.end())
-                        {
-                            /* Send response frame */
-                            generate_frames.routineControl(can_id, request[2], routine_identifier, true);
-                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame: installUpdates routine.", 0x31);
-                        } else
-                        {
-                            LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x31);
-                            NegativeResponse negative_response(socket, rc_logger);
-                            negative_response.sendNRC(can_id, 0x31, 0x78);
-                        }
+                        /* Send response frame */
+                        generate_frames.routineControl(can_id, request[2], routine_identifier, true);
+                        LOG_INFO(rc_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame: installUpdates routine.", 0x31);
+                        battery->stop_flags[0x31] = false;
                         break;
                     default:
                         LOG_ERROR(rc_logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);

--- a/src/uds/tester_present/src/TesterPresent.cpp
+++ b/src/uds/tester_present/src/TesterPresent.cpp
@@ -47,30 +47,16 @@ void TesterPresent::handleTesterPresent(uint32_t can_id, std::vector<uint8_t> da
     switch(receiver_id)
     {
         case 0x10:
-            if (MCU::mcu->stop_flags.find(0x3E) != MCU::mcu->stop_flags.end())
-            {
-                /* Send response frame */
-                this->generate->testerPresent(can_id, true);
-                LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x3E);
-            } else
-            {
-                LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x3E);
-                NegativeResponse negative_response(socket, *logger);
-                negative_response.sendNRC(can_id, 0x3E, 0x78);
-            }
+            /* Send response frame */
+            this->generate->testerPresent(can_id, true);
+            LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x3E);
+            MCU::mcu->stop_flags[0x3E] = false;
             break;
         case 0x11:
-            if (battery->stop_flags.find(0x3E) != battery->stop_flags.end())
-            {
-                /* Send response frame */
-                this->generate->testerPresent(can_id, true);
-                LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x3E);
-            } else
-            {
-                LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x3E);
-                NegativeResponse negative_response(socket, *logger);
-                negative_response.sendNRC(can_id, 0x3E, 0x78);
-            }
+            /* Send response frame */
+            this->generate->testerPresent(can_id, true);
+            LOG_INFO(logger->GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x3E);
+            battery->stop_flags[0x3E] = false;
             break;
         default:
             LOG_ERROR(logger->GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);

--- a/src/uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp
+++ b/src/uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp
@@ -107,30 +107,16 @@ void WriteDataByIdentifier::WriteDataByIdentifierService(canid_t frame_id, std::
         switch(receiver_id)
         {
             case 0x10:
-                if (MCU::mcu->stop_flags.find(0x2E) != MCU::mcu->stop_flags.end())
-                {
-                    /* Send response frame */
-                    generate_frames.writeDataByIdentifier(id, did, {});
-                    LOG_INFO(wdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x2E);
-                } else
-                {
-                    LOG_INFO(wdbi_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x2E);
-                    NegativeResponse negative_response(socket, wdbi_logger);
-                    negative_response.sendNRC(id, 0x2E, 0x78);
-                }
+                /* Send response frame */
+                generate_frames.writeDataByIdentifier(id, did, {});
+                LOG_INFO(wdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x2E);
+                MCU::mcu->stop_flags[0x2E] = false;
                 break;
             case 0x11:
-                if (battery->stop_flags.find(0x2E) != battery->stop_flags.end())
-                {
-                    /* Send response frame */
-                    generate_frames.writeDataByIdentifier(id, did, {});
-                    LOG_INFO(wdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x2E);
-                } else
-                {
-                    LOG_INFO(wdbi_logger.GET_LOGGER(), "Service with SID {:x} failed to send the response frame.", 0x2E);
-                    NegativeResponse negative_response(socket, wdbi_logger);
-                    negative_response.sendNRC(id, 0x2E, 0x78);
-                }
+                /* Send response frame */
+                generate_frames.writeDataByIdentifier(id, did, {});
+                LOG_INFO(wdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x2E);
+                battery->stop_flags[0x2E] = false;
                 break;
             default:
                 LOG_ERROR(wdbi_logger.GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);


### PR DESCRIPTION
- I made it so that when a service exceeds the processing limit from ATP, it sends a Response-Pending NRC to let the client know the request is still being processed. Once the service finishes processing, it sends the response.
- Also, I added logic for services to consider either the p2_max_time or p2_start_max_time timer, depending on how long each service should take at most.

## Trello link [here](https://trello.com/c/yDxJwrbq/27-integrate-dsc-atp-services)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
