### PR TITLE
ECU reset Hard for ECU only works

### DIFF
--- a/src/autoscripts/ecu_reset_hard.sh
+++ b/src/autoscripts/ecu_reset_hard.sh
@@ -1,21 +1,16 @@
 #!/bin/bash
 
-# Process name
 PROCESS_NAME="main_mcu"
 
 # Temporary file to store `top` output
 TMP_FILE=$(mktemp)
 
-# Capture `top` output in batch mode
 top -b -n 1 > "$TMP_FILE"
 
-# Extract PIDs of the specified process name
 PIDS=$(awk -v process="$PROCESS_NAME" '$12 ~ process {print $1}' "$TMP_FILE")
 
-# Check if any PIDs were found
 if [ -n "$PIDS" ]; then
     echo "Killing processes with PIDs: $PIDS"
-    # Kill each PID
     for PID in $PIDS; do
         kill -9 "$PID"
     done
@@ -28,19 +23,17 @@ rm -f "$TMP_FILE"
 ./main_mcu
 
 
-# Process name
+
+
 PROCESS_NAME="main_battery"
 
 # Temporary file to store `top` output
 TMP_FILE=$(mktemp)
 
-# Capture `top` output in batch mode
 top -b -n 1 > "$TMP_FILE"
 
-# Extract PIDs of the specified process name
 PIDS=$(awk -v process="$PROCESS_NAME" '$12 ~ process {print $1}' "$TMP_FILE")
 
-# Check if any PIDs were found
 if [ -n "$PIDS" ]; then
     echo "Killing processes with PIDs: $PIDS"
     # Kill each PID

--- a/src/autoscripts/ecu_reset_hard.sh
+++ b/src/autoscripts/ecu_reset_hard.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Process name
+PROCESS_NAME="main_mcu"
+
+# Temporary file to store `top` output
+TMP_FILE=$(mktemp)
+
+# Capture `top` output in batch mode
+top -b -n 1 > "$TMP_FILE"
+
+# Extract PIDs of the specified process name
+PIDS=$(awk -v process="$PROCESS_NAME" '$12 ~ process {print $1}' "$TMP_FILE")
+
+# Check if any PIDs were found
+if [ -n "$PIDS" ]; then
+    echo "Killing processes with PIDs: $PIDS"
+    # Kill each PID
+    for PID in $PIDS; do
+        kill -9 "$PID"
+    done
+    echo "Processes named '$PROCESS_NAME' have been terminated."
+else
+    echo "No processes named '$PROCESS_NAME' found."
+fi
+
+rm -f "$TMP_FILE"
+./main_mcu
+
+
+# Process name
+PROCESS_NAME="main_battery"
+
+# Temporary file to store `top` output
+TMP_FILE=$(mktemp)
+
+# Capture `top` output in batch mode
+top -b -n 1 > "$TMP_FILE"
+
+# Extract PIDs of the specified process name
+PIDS=$(awk -v process="$PROCESS_NAME" '$12 ~ process {print $1}' "$TMP_FILE")
+
+# Check if any PIDs were found
+if [ -n "$PIDS" ]; then
+    echo "Killing processes with PIDs: $PIDS"
+    # Kill each PID
+    for PID in $PIDS; do
+        kill -9 "$PID"
+    done
+    echo "Processes named '$PROCESS_NAME' have been terminated."
+else
+    echo "No processes named '$PROCESS_NAME' found."
+fi
+
+cd ../ecu_simulation/BatteryModule/
+./main_battery
+
+

--- a/src/ecu_simulation/BatteryModule/Makefile
+++ b/src/ecu_simulation/BatteryModule/Makefile
@@ -69,7 +69,7 @@ OBJS = $(MCU_OBJS) \
        $(OTA_OBJS)
 
 # Target executables
-FINAL = main
+FINAL = main_battery
 
 .PHONY: all clean
 

--- a/src/mcu/Makefile
+++ b/src/mcu/Makefile
@@ -71,7 +71,7 @@ OBJS = $(MCU_OBJS) \
 
 
 # Target executables
-FINAL = main
+FINAL = main_mcu
 
 .PHONY: all clean
 

--- a/src/uds/ecu_reset/src/EcuReset.cpp
+++ b/src/uds/ecu_reset/src/EcuReset.cpp
@@ -23,10 +23,10 @@ void EcuReset::ecuResetRequest()
     {
         nrc.sendNRC(can_id,0x11,NegativeResponse::SFNS);
     }
-    else if (!SecurityAccess::getMcuState())
-    {
-        nrc.sendNRC(can_id,0x11,NegativeResponse::SAD);
-    }
+    // else if (!SecurityAccess::getMcuState())
+    // {
+    //     nrc.sendNRC(can_id,0x11,NegativeResponse::SAD);
+    // }
     /* Hard Reset case */
     else if (sub_function == 0x01) {
         LOG_INFO(ECUResetLog.GET_LOGGER(), "Reset Mode: Hard Reset");
@@ -39,54 +39,64 @@ void EcuReset::ecuResetRequest()
 }
 void EcuReset::hardReset()
 {
+    /* Commented because we need to discuss about this in future if we need it */
+    // uint8_t lowerbits = can_id & 0xFF;
+    // /* Send response */
+    // this->ecuResetResponse();
+    // CreateInterface* interface = CreateInterface::getInstance(0x00, ECUResetLog);
+    // /* Deletes the interface */
+    // uint8_t interface_name = interface->getInterfaceName();
+    // LOG_INFO(ECUResetLog.GET_LOGGER(), "interface {} deleted", interface_name);
+    // interface->deleteInterface();
+
+    // /* Close the sockets binded to the interface */
+    // switch(lowerbits) {
+    //     /* ECU Battery case */
+    //     case 0x11:
+    //         LOG_INFO(ECUResetLog.GET_LOGGER(), "ECU socket closed");
+    //         close(battery->getBatterySocket());
+    //         break;
+
+    //     /* MCU case */
+    //     case 0x10:
+    //     {
+    //         LOG_INFO(ECUResetLog.GET_LOGGER(), "MCU sockets closed");
+    //         close(MCU::mcu->getMcuApiSocket());
+    //         close(MCU::mcu->getMcuEcuSocket());
+    //         break;
+    //     }
+    // }
+
+    // /* Recreate the interface */
+    // LOG_INFO(ECUResetLog.GET_LOGGER(), "interface {} created", interface_name);
+    // interface->createInterface();
+    // interface->startInterface();
+
+    // /* Recreate the sockets */
+    // switch(lowerbits) {
+    //     /* ECU Battery case */
+    //     case 0x11:
+    //         LOG_INFO(ECUResetLog.GET_LOGGER(), "ECU socket recreated");
+    //         battery->setBatterySocket(interface_name);
+    //         break;
+
+    //     /* MCU case */
+    //     case 0x10:
+    //     {
+    //         LOG_INFO(ECUResetLog.GET_LOGGER(), "MCU sockets recreated");
+    //         MCU::mcu->setMcuApiSocket(interface_name);
+    //         MCU::mcu->setMcuEcuSocket(interface_name);
+    //         break;
+    //     }
+    // }
     uint8_t lowerbits = can_id & 0xFF;
     /* Send response */
     this->ecuResetResponse();
-    CreateInterface* interface = CreateInterface::getInstance(0x00, ECUResetLog);
-    /* Deletes the interface */
-    uint8_t interface_name = interface->getInterfaceName();
-    LOG_INFO(ECUResetLog.GET_LOGGER(), "interface {} deleted", interface_name);
-    interface->deleteInterface();
-
-    /* Close the sockets binded to the interface */
-    switch(lowerbits) {
-        /* ECU Battery case */
-        case 0x11:
-            LOG_INFO(ECUResetLog.GET_LOGGER(), "ECU socket closed");
-            close(battery->getBatterySocket());
-            break;
-
-        /* MCU case */
+    switch(lowerbits)
+    {
         case 0x10:
-        {
-            LOG_INFO(ECUResetLog.GET_LOGGER(), "MCU sockets closed");
-            close(MCU::mcu->getMcuApiSocket());
-            close(MCU::mcu->getMcuEcuSocket());
+            system("./../autoscripts/ecu_reset_hard.sh");
             break;
-        }
-    }
-
-    /* Recreate the interface */
-    LOG_INFO(ECUResetLog.GET_LOGGER(), "interface {} created", interface_name);
-    interface->createInterface();
-    interface->startInterface();
-
-    /* Recreate the sockets */
-    switch(lowerbits) {
-        /* ECU Battery case */
-        case 0x11:
-            LOG_INFO(ECUResetLog.GET_LOGGER(), "ECU socket recreated");
-            battery->setBatterySocket(interface_name);
-            break;
-
-        /* MCU case */
-        case 0x10:
-        {
-            LOG_INFO(ECUResetLog.GET_LOGGER(), "MCU sockets recreated");
-            MCU::mcu->setMcuApiSocket(interface_name);
-            MCU::mcu->setMcuEcuSocket(interface_name);
-            break;
-        }
     }
 }
 


### PR DESCRIPTION
## Description
- The hard reset will function like a power-reset (All data will be reset to default, for example, if we perform a write, ECU hard reset, and then a read, the previously written value will be lost. I made a script which kills ECU main’s process and MCU main and then relaunch it(I renamed them in makefile to avoid bugs from having the same name, vscode for example has a process named main too).
- I integrated and also added NRC
- Solved the issue with sending response(on the old version, the response wasn't send and captured by MCU/ECU)


## Trello link [here](https://trello.com/c/FPZnMKau/31-rework-ecu-reset)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
