### PR TITLE
change sw versioning logic to use 8 bits instead of 7 and remove down…

### DIFF
--- a/src/autoscripts/ReleaseScript.py
+++ b/src/autoscripts/ReleaseScript.py
@@ -87,8 +87,8 @@ def validateSoftwareVersion(software_version):
     major_version = int(major_version)
     minor_version = int(minor_version)
 
-    if major_version < 1 or major_version > 8 or minor_version < 0 or minor_version > 15:
-        print("Version not valid. Valid versions are between 1.0 and 8.15")
+    if major_version < 1 or major_version > 16 or minor_version < 0 or minor_version > 15:
+        print("Version not valid. Valid versions are between 1.0 and 16.15")
         exit(-1)
     return software_version
 

--- a/src/ota/google_drive_api/GoogleDriveApi.py
+++ b/src/ota/google_drive_api/GoogleDriveApi.py
@@ -116,7 +116,7 @@ class GDriveAPI:
 
         # Most significant 4 bits => major version, least significant 4 bits minor_version. Major version can't start with 0 => +1
         major_version = ((int_value & 0b11110000) >> 4) + 1
-        minor_version =  (int_value & 0b00001111)
+        minor_version = (int_value & 0b00001111)
 
         # Combine the parts into the version string
         software_version = f"{major_version}.{minor_version}"

--- a/src/ota/google_drive_api/GoogleDriveApi.py
+++ b/src/ota/google_drive_api/GoogleDriveApi.py
@@ -114,9 +114,9 @@ class GDriveAPI:
         # Convert the hex string to an integer
         int_value = int(str(software_version_byte), 16)
 
-        # SMost significant 3 bits => major version, next 4 bits minor_version, lsb not important for versioning
-        major_version = ((int_value & 0b11100000) >> 5) + 1
-        minor_version = (int_value & 0b00011110) >> 1
+        # Most significant 4 bits => major version, least significant 4 bits minor_version. Major version can't start with 0 => +1
+        major_version = ((int_value & 0b11110000) >> 4) + 1
+        minor_version =  (int_value & 0b00001111)
 
         # Combine the parts into the version string
         software_version = f"{major_version}.{minor_version}"

--- a/src/ota/request_download/src/RequestDownload.cpp
+++ b/src/ota/request_download/src/RequestDownload.cpp
@@ -117,30 +117,15 @@ void RequestDownloadService::requestDownloadRequest(canid_t id, std::vector<uint
         }
 
         /* Calculate the position for manual update 0 or automatic update 1 */ 
-        size_t position_download_type = 4 + length_memory_address + length_memory_size;
-        uint8_t download_type = stored_data[position_download_type];
+        size_t position_software_version = 4 + length_memory_address + length_memory_size;
+        uint8_t software_version = stored_data[position_software_version];
         /* 0x24 => 0010 010 0* => v2.2, LSB not taken in consideration for versioning */
-        downloadSoftwareVersion(receiver_id, download_type);
-       
-        if (position_download_type < stored_data.size()) 
-        {
-            /* we take only the first bit from download_type */
-            download_type = stored_data[position_download_type] & 0x01;
-            LOG_INFO(RDSlogger.GET_LOGGER(), "download_type: 0x{:02X}", download_type);
-        }
+        downloadSoftwareVersion(receiver_id, software_version);
 
         int max_number_block = calculate_max_number_block(memory_size);
 
-        if (download_type == 0x00)
-        {
-            requestDownloadResponse(id, memory_address, max_number_block);
-            return;
-        }
-        else if (download_type == 0x01)
-        {
-            requestDownloadAutomatic(id, memory_address, max_number_block);
-            return;
-        }
+        requestDownloadResponse(id, memory_address, max_number_block);
+        return;
     }
 }
 


### PR DESCRIPTION

## Description

Removed download_type bit from request download service. Downloads will be manual. That bit is used for software versioning. Now we can have 16 major versions and 16 minor versions.

## Trello link [here](https://trello.com/c/HbumdRj9/20-update-software-versioning-logic)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
