### PR TITLE
Add files to keep the mcu and battery data

### DIFF
--- a/src/ecu_simulation/BatteryModule/include/BatteryModule.h
+++ b/src/ecu_simulation/BatteryModule/include/BatteryModule.h
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <unistd.h>
 #include <future>
+#include <fstream>
 #include "../../../utils/include/CreateInterface.h"
 #include "ReceiveFrames.h"
 #include "../../../utils/include/GenerateFrames.h"
@@ -52,7 +53,7 @@ public:
     /* Stop flags for each SID. */
     static std::map<uint8_t, std::atomic<bool>> stop_flags;
     /* Variable to store ecu data */
-    std::unordered_map<uint16_t, std::vector<uint8_t>> ecu_data = {
+    std::unordered_map<uint16_t, std::vector<uint8_t>> default_DID_battery = {
         {0x01A0, {0}},  /* Energy Level */
         {0x01B0, {0}},  /* Voltage */
         {0x01C0, {0}},  /* Percentage */

--- a/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
+++ b/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
@@ -17,6 +17,24 @@ BatteryModule::BatteryModule() : moduleId(0x11),
                                  canInterface(CreateInterface::getInstance(0x00, *batteryModuleLogger)),
                                  frameReceiver(nullptr)
 {
+    /* Insert the default DID values in the file */
+    std::ofstream outfile("battery_data.txt");
+    if (!outfile.is_open())
+    {
+        throw std::runtime_error("Failed to open file: battery_data.txt");
+    }
+
+    for (const auto& [data_identifier, data] : default_DID_battery)
+    {
+        outfile << std::hex << std::setw(4) << std::setfill('0') << data_identifier << " ";
+        for (uint8_t byte : data) 
+        {
+            outfile << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(byte) << " ";
+        }
+        outfile << "\n";
+    }
+    outfile.close();
+
     battery_socket = canInterface->createSocket(0x00);
     /* Initialize the Frame Receiver */
     frameReceiver = new ReceiveFrames(battery_socket, moduleId);
@@ -35,6 +53,24 @@ BatteryModule::BatteryModule(int _interfaceNumber, int _moduleId) : moduleId(_mo
                                                                     canInterface(CreateInterface::getInstance(_interfaceNumber, *batteryModuleLogger)),
                                                                     frameReceiver(nullptr)
 {
+    /* Insert the default DID values in the file */
+    std::ofstream outfile("battery_data.txt");
+    if (!outfile.is_open())
+    {
+        throw std::runtime_error("Failed to open file: battery_data.txt");
+    }
+
+    for (const auto& [data_identifier, data] : default_DID_battery)
+    {
+        outfile << std::hex << std::setw(4) << std::setfill('0') << std::uppercase << data_identifier << " ";
+        for (uint8_t byte : data)
+        {
+            outfile << std::hex << std::setw(1) << std::setfill('0') << static_cast<int>(byte) << " ";
+        }
+        outfile << "\n";
+    }
+    outfile.close();
+
     battery_socket = canInterface->createSocket(0x00);
     /* Initialize the Frame Receiver */
     frameReceiver = new ReceiveFrames(battery_socket, moduleId);
@@ -92,61 +128,100 @@ void BatteryModule::parseBatteryInfo(const std::string &data, float &energy, flo
 {
     std::istringstream stream(data);
     std::string line;
+    std::unordered_map<uint16_t, std::string> updated_values;
 
     while (std::getline(stream, line))
     {
         if (line.find("energy:") != std::string::npos)
         {
             energy = std::stof(line.substr(line.find(":") + 1));
-            ecu_data[0x01A0] = {static_cast<uint8_t>(energy)};
+            updated_values[0x01A0] = std::to_string(static_cast<uint8_t>(energy));
         }
         else if (line.find("voltage:") != std::string::npos)
         {
             voltage = std::stof(line.substr(line.find(":") + 1));
-            ecu_data[0x01B0] = {static_cast<uint8_t>(voltage)};
+            updated_values[0x01B0] = std::to_string(static_cast<uint8_t>(voltage));
         }
         else if (line.find("percentage:") != std::string::npos)
         {
             percentage = std::stof(line.substr(line.find(":") + 1));
-            ecu_data[0x01C0] = {static_cast<uint8_t>(percentage)};
+            updated_values[0x01C0] = std::to_string(static_cast<uint8_t>(percentage));
         }
         else if (line.find("state:") != std::string::npos)
         {
             size_t pos = line.find(":");
-            /* Extract substring starting from the first non-whitespace character after ':' */
             state = line.substr(pos + 1);
-            /* Remove leading whitespace */
             state = state.substr(state.find_first_not_of(" \t"));
-            if(state == "unknown")
+
+            /* default: unknown */
+            uint8_t state_value = 0x00;
+            if (state == "charging")
             {
-                ecu_data[0x01D0] = {0x00};
+                state_value = 0x01;
             }
-            else if(state == "charging")
+            else if (state == "discharging")
             {
-                ecu_data[0x01D0] = {0x01};
+                state_value = 0x02;
             }
-            else if(state == "discharging")
+            else if (state == "empty")
             {
-                ecu_data[0x01D0] = {0x02};
+                state_value = 0x03;
             }
-            else if(state == "empty")
+            else if (state == "fully-charged")
             {
-                ecu_data[0x01D0] = {0x03};
+                state_value = 0x04;
             }
-            else if(state == "fully-charged")
+            else if (state == "pending-charge")
             {
-                ecu_data[0x01D0] = {0x04};
+                state_value = 0x05;
             }
-            else if(state == "pending-charge")
+            else if (state == "pending-discharge")
             {
-                ecu_data[0x01D0] = {0x05};
+                state_value = 0x06;
             }
-            else if(state == "pending-discharge")
-            {
-                ecu_data[0x01D0] = {0x06};
-            }
+            updated_values[0x01D0] = std::to_string(state_value);
         }
     }
+
+    /* Path to battery data file */
+    std::string file_path = "battery_data.txt";
+
+    /* Read the current file contents into memory */
+    std::ifstream infile(file_path);
+    std::stringstream buffer;
+    buffer << infile.rdbuf();
+    infile.close();
+
+    std::string file_contents = buffer.str();
+    std::istringstream file_stream(file_contents);
+    std::string updated_file_contents;
+    std::string file_line;
+
+    /* Update the relevant DID values in the file contents */
+    while (std::getline(file_stream, file_line))
+    {
+        bool updated = false;
+        for (const auto &pair : updated_values)
+        {
+            std::stringstream did_ss;
+            did_ss << std::hex << std::setw(4) << std::setfill('0') << std::uppercase << pair.first;
+            if (file_line.find(did_ss.str()) != std::string::npos)
+            {
+                updated_file_contents += did_ss.str() + " " + pair.second + "\n";
+                updated = true;
+                break;
+            }
+        }
+        if (!updated)
+        {
+            updated_file_contents += file_line + "\n";
+        }
+    }
+
+    /* Write the updated contents back to the file */
+    std::ofstream outfile(file_path);
+    outfile << updated_file_contents;
+    outfile.close();
 }
 
 /* Function to fetch data from system about battery */

--- a/src/mcu/include/MCUModule.h
+++ b/src/mcu/include/MCUModule.h
@@ -16,6 +16,10 @@
 
 #include <thread>
 #include <future>
+#include <fstream>
+#include <stdexcept>
+#include <filesystem>
+
 namespace MCU
 {
     class MCUModule {
@@ -28,7 +32,7 @@ namespace MCU
         static std::map<uint8_t, std::atomic<bool>> stop_flags;
 
         /* Variable to store mcu data */
-        std::unordered_map<uint16_t, std::vector<uint8_t>> mcu_data = 
+        std::unordered_map<uint16_t, std::vector<uint8_t>> default_DID_MCU = 
         {
             {0x01E0, {IDLE}}
         };

--- a/src/mcu/src/MCUModule.cpp
+++ b/src/mcu/src/MCUModule.cpp
@@ -16,13 +16,50 @@ namespace MCU
                     mcu_ecu_socket(create_interface->createSocket(interfaces_number >> 4))
                     {
 
+        /* Insert the default DID values in the file */
+        std::ofstream outfile("mcu_data.txt");
+        if (!outfile.is_open())
+        {
+            throw std::runtime_error("Failed to open file: mcu_data.txt");
+        }
+
+        for (const auto& [data_identifier, data] : default_DID_MCU)
+        {
+            outfile << std::hex << std::setw(4) << std::setfill('0') << std::uppercase << data_identifier << " ";
+            for (uint8_t byte : data)
+            {
+                outfile << std::hex << std::setw(1) << std::setfill('0') << static_cast<int>(byte) << " ";
+            }
+            outfile << "\n";
+        }
+        outfile.close();
+
         receive_frames = new ReceiveFrames(mcu_ecu_socket, mcu_api_socket);
     }
 
     /* Default constructor */
     MCUModule::MCUModule() : is_running(false),
                          create_interface(CreateInterface::getInstance(0x01, *MCULogger)),
-                         receive_frames(nullptr) {}
+                         receive_frames(nullptr)
+    {
+        /* Insert the default DID values in the file */
+        std::ofstream outfile("mcu_data.txt");
+        if (!outfile.is_open())
+        {
+            throw std::runtime_error("Failed to open file: mcu_data.txt");
+        }
+
+        for (const auto& [data_identifier, data] : default_DID_MCU)
+        {
+            outfile << std::hex << std::setw(4) << std::setfill('0') << std::uppercase << data_identifier << " ";
+            for (uint8_t byte : data)
+            {
+                outfile << std::hex << std::setw(1) << std::setfill('0') << static_cast<int>(byte) << " ";
+            }
+            outfile << "\n";
+        }
+        outfile.close();
+    }
 
     /* Destructor */
     MCUModule::~MCUModule() 

--- a/src/ota/request_transfer_exit/src/RequestTransferExit.cpp
+++ b/src/ota/request_transfer_exit/src/RequestTransferExit.cpp
@@ -67,12 +67,30 @@ void RequestTransferExit::requestTRansferExitRequest(canid_t can_id, const std::
     }
     else    
     {
-        /* Retrieve transfer_status based on the OTA_UPDATE_STATUS_DID if it exists */
-        if ( MCU::mcu->mcu_data.find(0x01E0) != MCU::mcu->mcu_data.end())
+        std::ifstream file("mcu_data.txt");
+        std::string line;
+        uint8_t value;
+        bool did_found = false;
+        
+        while (std::getline(file, line))
         {
-            uint8_t transfer_status = MCU::mcu->mcu_data.at(0x01E0)[0];
+            std::istringstream iss(line);
+            std::string key_str;
+            uint16_t key;
+            
+            if (iss >> std::hex >> key && key == 0x01E0)
+            {
+                /* Read the first byte associated with the DID */
+                iss >> std::hex >> value;
+                did_found = true;
+                break;
+            }
+        }
+        /* Retrieve transfer_status based on the OTA_UPDATE_STATUS_DID if it exists */
+        if (did_found != 01)
+        {
             /* Check if the transfer data has been completed */
-            if (transfer_status == 0x31)        
+            if (value == 0x31)        
                 {
                 /* prepare positive response */
                 response.push_back(0x02); /* PCI */

--- a/src/uds/access_timing_parameters/src/AccessTimingParameter.cpp
+++ b/src/uds/access_timing_parameters/src/AccessTimingParameter.cpp
@@ -23,7 +23,8 @@ AccessTimingParameter::~AccessTimingParameter()
 
 void AccessTimingParameter::handleRequest(canid_t frame_id, uint8_t sub_function, std::vector<uint8_t> frame_data)
 {
-    LOG_INFO(atp_logger.GET_LOGGER(), "Function that handle frames in ATP service called with subfunction 0x{:x}.", sub_function);
+    LOG_INFO(atp_logger.GET_LOGGER(), "Function that handle frames in ATP service called with subfunction 0x{:x}.", sub_function);\
+    uint8_t receiver_id = frame_id & 0xFF;
     switch (sub_function)
     {
         case 0x01:
@@ -44,12 +45,29 @@ void AccessTimingParameter::handleRequest(canid_t frame_id, uint8_t sub_function
             {
                 /* Call negative response service with NRC 0x13 */
                 LOG_ERROR(atp_logger.GET_LOGGER(), "Incorrect Message Length Or Invalid Format");
+                NegativeResponse negative_response(socket, atp_logger);
+                negative_response.sendNRC(frame_id, 0x83, 0x13);
+                if (receiver_id == 0x10)
+                {
+                    MCU::mcu->stop_flags[0x83] = false;
+                } else if (receiver_id == 0x11)
+                {
+                    battery->stop_flags[0x83] = false;
+                }
             }
             break;
         default:
             /* Call negative response service with NRC 0x12 */
             LOG_ERROR(atp_logger.GET_LOGGER(), "Unsupported sub-function");
-            return;
+            NegativeResponse negative_response(socket, atp_logger);
+            negative_response.sendNRC(frame_id, 0x83, 0x12);
+            if (receiver_id == 0x10)
+            {
+                MCU::mcu->stop_flags[0x83] = false;
+            } else if (receiver_id == 0x11)
+            {
+                battery->stop_flags[0x83] = false;
+            }
             break;
     }
 }
@@ -114,6 +132,11 @@ void AccessTimingParameter::readExtendedTimingParameters(canid_t frame_id)
             default:
                 LOG_ERROR(atp_logger.GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);
         }
+        if (receiver_id == 0x10) {
+            MCU::mcu->stop_flags[0x83] = false;
+        } else if (receiver_id == 0x11) {
+            battery->stop_flags[0x83] = false;
+        }
 }
 
 void AccessTimingParameter::setTimingParametersToDefault(canid_t frame_id)
@@ -163,6 +186,11 @@ void AccessTimingParameter::setTimingParametersToDefault(canid_t frame_id)
                 break;
             default:
                 LOG_ERROR(atp_logger.GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);
+        }
+        if (receiver_id == 0x10) {
+            MCU::mcu->stop_flags[0x83] = false;
+        } else if (receiver_id == 0x11) {
+            battery->stop_flags[0x83] = false;
         }
 }
 
@@ -225,6 +253,11 @@ void AccessTimingParameter::readCurrentlyActiveTimingParameters(canid_t frame_id
                 break;
             default:
                 LOG_ERROR(atp_logger.GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);
+        }
+        if (receiver_id == 0x10) {
+            MCU::mcu->stop_flags[0x83] = false;
+        } else if (receiver_id == 0x11) {
+            battery->stop_flags[0x83] = false;
         }
 }
 

--- a/src/uds/clear_dtc/src/ClearDtc.cpp
+++ b/src/uds/clear_dtc/src/ClearDtc.cpp
@@ -24,6 +24,11 @@ void ClearDtc::clearDtc(int id, std::vector<uint8_t> data)
     {
         LOG_ERROR(logger->GET_LOGGER(), "Incorrect message length or invalid format");
         this->generate->negativeResponse(new_id, 0x14, 0x13);
+        if (lowerbits == 0x10) {
+            MCU::mcu->stop_flags[0x14] = false;
+        } else if (lowerbits == 0x11) {
+            battery->stop_flags[0x14] = false;
+        }
         return;
     }
 
@@ -32,6 +37,13 @@ void ClearDtc::clearDtc(int id, std::vector<uint8_t> data)
     {
         LOG_ERROR(logger->GET_LOGGER(), "RequestOutOfRange NRC:Specified Group of DTC parameter is not supported");
         this->generate->negativeResponse(new_id, 0x14, 0x31);
+        if (lowerbits == 0x10)
+        {
+            MCU::mcu->stop_flags[0x14] = false;
+        } else if (lowerbits == 0x11)
+        {
+            battery->stop_flags[0x14] = false;
+        }
     }
 
     std::ofstream temp;
@@ -77,6 +89,13 @@ void ClearDtc::clearDtc(int id, std::vector<uint8_t> data)
     {
         LOG_ERROR(logger->GET_LOGGER(), "conditionsNotCorrect NRC: Error trying to open the DTC file");
         this->generate->negativeResponse(new_id, 0x14, 0x22);
+        if (lowerbits == 0x10)
+        {
+            MCU::mcu->stop_flags[0x14] = false;
+        } else if (lowerbits == 0x11)
+        {
+            battery->stop_flags[0x14] = false;
+        }
         return;
     }
     std::string line;

--- a/src/uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp
+++ b/src/uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp
@@ -42,6 +42,14 @@ void DiagnosticSessionControl::sessionControl(canid_t frame_id, uint8_t sub_func
         LOG_ERROR(dsc_logger->GET_LOGGER(), "Unsupported sub-function");
         NegativeResponse negative_response(socket, *dsc_logger);
         negative_response.sendNRC(frame_id, 0x10, 0x12);
+        uint8_t receiver_id = frame_id & 0xFF;
+        if (receiver_id == 0x10)
+        {
+            MCU::mcu->stop_flags[0x10] = false;
+        } else if (receiver_id == 0x11)
+        {
+            battery->stop_flags[0x10] = false;
+        }
         break;
     }
 }

--- a/src/uds/ecu_reset/src/EcuReset.cpp
+++ b/src/uds/ecu_reset/src/EcuReset.cpp
@@ -22,6 +22,13 @@ void EcuReset::ecuResetRequest()
     if (sub_function != 0x01 && sub_function != 0x02)
     {
         nrc.sendNRC(can_id,0x11,NegativeResponse::SFNS);
+        if (lowerbits == 0x10)
+        {
+            MCU::mcu->stop_flags[0x11] = false;
+        } else if (lowerbits == 0x11)
+        {
+            battery->stop_flags[0x11] = false;
+        }
     }
     // else if (!SecurityAccess::getMcuState())
     // {

--- a/src/uds/read_data_by_identifier/include/ReadDataByIdentifier.h
+++ b/src/uds/read_data_by_identifier/include/ReadDataByIdentifier.h
@@ -16,6 +16,9 @@
 #include <vector>
 #include <unordered_map>
 #include <bitset>
+#include <fstream>
+#include <sstream>
+#include <string>
 
 #include "../../../utils/include/GenerateFrames.h"
 #include "../../utils/include/Logger.h"

--- a/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
+++ b/src/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
@@ -2,6 +2,46 @@
 #include "../../../ecu_simulation/BatteryModule/include/BatteryModule.h"
 #include "../../../mcu/include/MCUModule.h"
 
+/* Helper function to read data from a file */
+std::vector<uint8_t> readDataFromFile(const std::string& file_name, uint16_t data_identifier)
+{
+    std::ifstream infile(file_name);
+    std::vector<uint8_t> response;
+
+    if (!infile.is_open())
+    {
+        throw std::runtime_error("Failed to open file: " + file_name);
+    }
+
+    std::string line;
+    while (std::getline(infile, line))
+    {
+        std::istringstream iss(line);
+        uint16_t identifier;
+        uint16_t value;
+        std::vector<uint8_t> data;
+
+        // Read the identifier from the line
+        if (iss >> std::hex >> identifier)
+        {
+            // Read the remaining data values
+            while (iss >> std::hex >> value)
+            {
+                data.push_back(value);
+            }
+            // Check if the identifier matches the requested one
+            if (identifier == data_identifier)
+            {
+                response = data;
+                break;
+            }
+        }
+    }
+
+    infile.close();
+    return response;
+}
+
 ReadDataByIdentifier::ReadDataByIdentifier(int socket, Logger* rdbi_logger) 
             : generate_frames(socket, *rdbi_logger), rdbi_logger(*rdbi_logger)
 {
@@ -9,40 +49,59 @@ ReadDataByIdentifier::ReadDataByIdentifier(int socket, Logger* rdbi_logger)
 }
 
 /* Function to handle the Read Data By Identifier request */
-std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, const std::vector<uint8_t>& request, bool use_send_frame) {
+std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t frame_id, const std::vector<uint8_t>& request, bool use_send_frame)
+{
     std::vector<uint8_t> response;
     NegativeResponse nrc(socket, rdbi_logger);
 
-    /* Extract the first 8 bits of can_id */
-    uint8_t lowerbits = can_id & 0xFF;
-    uint8_t upperbits = can_id >> 8 & 0xFF;
+    /* Extract the first 8 bits of frame_id */
+    uint8_t lowerbits = frame_id & 0xFF;
+    uint8_t upperbits = frame_id >> 8 & 0xFF;
 
     /* Reverse IDs */
-    can_id = ((lowerbits << 8) | upperbits);
+    canid_t can_id = ((lowerbits << 8) | upperbits);
 
     /* Check if the request size is less than 4 */
-    if (request.size() < 4) {
+    if (request.size() < 4)
+    {
         /* Invalid request length - prepare a negative response */
         response.push_back(0x03); /* PCI */
         response.push_back(0x7F); /* Negative response */
         response.push_back(RDBI_SERVICE_ID); /* Service ID */
         response.push_back(NegativeResponse::IMLOIF); /* Incorrect message length or invalid format */
 
-        if (use_send_frame) {
+        if (use_send_frame)
+        {
             /* Send the negative response frame */ 
-            nrc.sendNRC(can_id,RDBI_SERVICE_ID,NegativeResponse::IMLOIF);
+            nrc.sendNRC(can_id, RDBI_SERVICE_ID, NegativeResponse::IMLOIF);
+            if (lowerbits == 0x10)
+            {
+                MCU::mcu->stop_flags[0x22] = false;
+            } else if (lowerbits == 0x11)
+            {
+                battery->stop_flags[0x22] = false;
+            }
         }
 
         /* Return early as the request is invalid */
         return response;
     }
-    if (!SecurityAccess::getMcuState()) {
+    if (!SecurityAccess::getMcuState())
+    {
         response.push_back(0x03); /* PCI */
         response.push_back(0x7F); /* Negative response */
         response.push_back(RDBI_SERVICE_ID); /* Service ID */
         response.push_back(NegativeResponse::SAD); /* Security Access Denied */
-        if (use_send_frame) {
-            nrc.sendNRC(can_id,RDBI_SERVICE_ID,NegativeResponse::SAD);
+        if (use_send_frame)
+        {
+            nrc.sendNRC(can_id, RDBI_SERVICE_ID, NegativeResponse::SAD);
+            if (lowerbits == 0x10)
+            {
+                MCU::mcu->stop_flags[0x22] = false;
+            } else if (lowerbits == 0x11)
+            {
+                battery->stop_flags[0x22] = false;
+            }
         }
 
         return response;
@@ -50,71 +109,116 @@ std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t can_id, 
 
     /* Extract the data identifier from the request */
     uint16_t data_identifier = (request[2] << 8) | request[3];
+    std::string file_name;
 
-    /* Determine which ECU data storage to use based on the first 8 bits of can_id */
-    if ((lowerbits == 0x10 && MCU::mcu->mcu_data.find(data_identifier) != MCU::mcu->mcu_data.end()) ||
-        (lowerbits == 0x11 && battery->ecu_data.find(data_identifier) != battery->ecu_data.end())) {
-
-        /* Fetch the data based on the data identifier */
-        if (lowerbits == 0x10) {
-            response = MCU::mcu->mcu_data.at(data_identifier);
-        } else {
-            /* battery->fetchBatteryData(); */
-            response = (battery->ecu_data).at(data_identifier);
+    if (lowerbits == 0x10)
+    {
+        file_name = "mcu_data.txt";
+    } else if (lowerbits == 0x11)
+    {
+        file_name = "battery_data.txt";
+    } else
+    {
+        response.push_back(0x03); /* PCI */
+        response.push_back(0x7F); /* Negative response */
+        response.push_back(RDBI_SERVICE_ID); /* Service ID */
+        response.push_back(NegativeResponse::ROOR); /* Request out of range */
+        if (use_send_frame)
+        {
+            nrc.sendNRC(can_id, RDBI_SERVICE_ID, NegativeResponse::ROOR);
+            if (lowerbits == 0x10)
+            {
+                MCU::mcu->stop_flags[0x22] = false;
+            } else if (lowerbits == 0x11)
+            {
+                battery->stop_flags[0x22] = false;
+            }
         }
+        return response;
+    }
 
-    } else {
+    try
+    {
+        response = readDataFromFile(file_name, data_identifier);
+    } catch (const std::exception& e)
+    {
+        LOG_ERROR(rdbi_logger.GET_LOGGER(), "Error reading from file: {}", e.what());
+        response.push_back(0x03); /* PCI */
+        response.push_back(0x7F); /* Negative response */
+        response.push_back(RDBI_SERVICE_ID); /* Service ID */
+        response.push_back(NegativeResponse::ROOR); /* Request out of range */
+        if (use_send_frame)
+        {
+            nrc.sendNRC(can_id, RDBI_SERVICE_ID, NegativeResponse::ROOR);
+            if (lowerbits == 0x10)
+            {
+                MCU::mcu->stop_flags[0x22] = false;
+            } else if (lowerbits == 0x11)
+            {
+                battery->stop_flags[0x22] = false;
+            }
+        }
+        return response;
+    }
+
+    if (response.empty())
+    {
         /* Data identifier not found */
         response.push_back(0x03); /* PCI */
         response.push_back(0x7F); /* Negative response */
         response.push_back(RDBI_SERVICE_ID); /* Service ID */
         response.push_back(NegativeResponse::ROOR); /* Request out of range */
+        LOG_ERROR(rdbi_logger.GET_LOGGER(), "Error response empty");
         if (use_send_frame) {
-            /* Send the negative response frame */ 
-            nrc.sendNRC(can_id,RDBI_SERVICE_ID,NegativeResponse::ROOR);
+            nrc.sendNRC(can_id, RDBI_SERVICE_ID, NegativeResponse::ROOR);
+            if (lowerbits == 0x10)
+            {
+                MCU::mcu->stop_flags[0x22] = false;
+            } else if (lowerbits == 0x11)
+            {
+                battery->stop_flags[0x22] = false;
+            }
         }
         return response;
     }
 
-    if (use_send_frame) {
+    // Convert the response vector to a string for logging
+    std::ostringstream oss;
+    for (const auto& byte : response)
+    {
+        oss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(byte) << " ";
+    }
+
+    // Log the data
+    LOG_INFO(rdbi_logger.GET_LOGGER(), "Data for DID 0x{:04X} from {}: {}", data_identifier, file_name, oss.str());
+
+
+    if (use_send_frame)
+    {
         if (response.size() > 7)
         {
-            switch(lowerbits)
+            /* Send response frame */
+            generate_frames.readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
+            LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
+            if (lowerbits == 0x10)
             {
-                case 0x10:
-                    /* Send response frame */
-                    generate_frames.readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
-                    LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
-                    MCU::mcu->stop_flags[0x22] = false;
-                    break;
-                case 0x11:
-                    /* Send response frame */
-                    generate_frames.readDataByIdentifierLongResponse(can_id, data_identifier, response, true);
-                    LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
-                    battery->stop_flags[0x22] = false;
-                    break;
-                default:
-                    LOG_ERROR(rdbi_logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
+                MCU::mcu->stop_flags[0x22] = false;
+            } else if (lowerbits == 0x11)
+            {
+                battery->stop_flags[0x22] = false;
             }
         } 
         else
-        {   
-            switch(lowerbits)
+        {
+            /* Send response frame */
+            generate_frames.readDataByIdentifier(can_id, data_identifier, response);
+            LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
+            if (lowerbits == 0x10)
             {
-                case 0x10:
-                    /* Send response frame */
-                    generate_frames.readDataByIdentifier(can_id, data_identifier, response);
-                    LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
-                    MCU::mcu->stop_flags[0x22] = false;
-                    break;
-                case 0x11:
-                    /* Send response frame */
-                    generate_frames.readDataByIdentifier(can_id, data_identifier, response);
-                    LOG_INFO(rdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x22);
-                    battery->stop_flags[0x22] = false;
-                    break;
-                default:
-                    LOG_ERROR(rdbi_logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
+                MCU::mcu->stop_flags[0x22] = false;
+            } else if (lowerbits == 0x11)
+            {
+                battery->stop_flags[0x22] = false;
             }
         }
     }

--- a/src/uds/read_dtc_information/src/ReadDtcInformation.cpp
+++ b/src/uds/read_dtc_information/src/ReadDtcInformation.cpp
@@ -26,6 +26,13 @@ void ReadDTC::read_dtc(int id, std::vector<uint8_t> data)
     {
         LOG_ERROR(logger.GET_LOGGER(), "Incorrect message length or invalid format");
         this->generate->negativeResponse(new_id, 0x19, 0x13);
+        if (lowerbits == 0x10)
+        {
+            MCU::mcu->stop_flags[0x19] = false;
+        } else if (lowerbits == 0x11)
+        {
+            battery->stop_flags[0x19] = false;
+        }
         return;
     }
     int sub_function = data[2];
@@ -44,6 +51,13 @@ void ReadDTC::read_dtc(int id, std::vector<uint8_t> data)
         default:
             this->generate->negativeResponse(new_id, 0x19, 0x12);
             LOG_ERROR(logger.GET_LOGGER(), "Sub-function not supported");
+            if (lowerbits == 0x10)
+            {
+                MCU::mcu->stop_flags[0x19] = false;
+            } else if (lowerbits == 0x11)
+            {
+                battery->stop_flags[0x19] = false;
+            }
     }
 }
 
@@ -63,6 +77,14 @@ void ReadDTC::number_of_dtc(int id, int dtc_status_mask)
         LOG_ERROR(logger.GET_LOGGER(), "Unable to read DTCs");
         /* NRC Resource temporarily unavailable */
         this->generate->negativeResponse(id, 0x19, 0x94);
+        uint8_t lowerbits = id & 0xFF;
+        if (lowerbits == 0x10)
+        {
+            MCU::mcu->stop_flags[0x19] = false;
+        } else if (lowerbits == 0x11)
+        {
+            battery->stop_flags[0x19] = false;
+        }
         return;
     }
 
@@ -121,6 +143,14 @@ void ReadDTC::report_dtcs(int id, int dtc_status_mask)
         LOG_ERROR(logger.GET_LOGGER(), "Unable to read DTCs");
         /* NRC Resource temporarily unavailable */
         this->generate->negativeResponse(id, 0x19, 0x94);
+        uint8_t lowerbits = id & 0xFF;
+        if (lowerbits == 0x10)
+        {
+            MCU::mcu->stop_flags[0x19] = false;
+        } else if (lowerbits == 0x11)
+        {
+            battery->stop_flags[0x19] = false;
+        }
         return;
     }
     

--- a/src/uds/routine_control/src/RoutineControl.cpp
+++ b/src/uds/routine_control/src/RoutineControl.cpp
@@ -22,23 +22,51 @@ void RoutineControl::routineControl(canid_t can_id, const std::vector<uint8_t>& 
     {
         /* Incorrect message length or invalid format - prepare a negative response */
         nrc.sendNRC(can_id,ROUTINE_CONTROL_SID,NegativeResponse::IMLOIF);
+        if (lowerbits == 0x10)
+        {
+            MCU::mcu->stop_flags[0x31] = false;
+        } else if (lowerbits == 0x11)
+        {
+            battery->stop_flags[0x31] = false;
+        }
         return;
     }
     else if (request[2] < 0x01 || request [2] > 0x03)
     {
         /* Sub Function not supported - prepare a negative response */
         nrc.sendNRC(can_id,ROUTINE_CONTROL_SID,NegativeResponse::SFNS);
+        if (lowerbits == 0x10)
+        {
+            MCU::mcu->stop_flags[0x31] = false;
+        } else if (lowerbits == 0x11)
+        {
+            battery->stop_flags[0x31] = false;
+        }
         return;
     }
     else if (!SecurityAccess::getMcuState())
     {
         nrc.sendNRC(can_id,ROUTINE_CONTROL_SID,NegativeResponse::SAD);
+        if (lowerbits == 0x10)
+        {
+            MCU::mcu->stop_flags[0x31] = false;
+        } else if (lowerbits == 0x11)
+        {
+            battery->stop_flags[0x31] = false;
+        }
     }
     /* when our identifiers will be defined, this range should be smaller */
     else if (routine_identifier < 0x0100 || routine_identifier > 0xEFFF)
     {
         /* Request Out of Range - prepare a negative response */
         nrc.sendNRC(can_id,ROUTINE_CONTROL_SID,NegativeResponse::ROOR);
+        if (lowerbits == 0x10)
+        {
+            MCU::mcu->stop_flags[0x31] = false;
+        } else if (lowerbits == 0x11)
+        {
+            battery->stop_flags[0x31] = false;
+        }
         return;
     }
     else

--- a/src/uds/tester_present/src/TesterPresent.cpp
+++ b/src/uds/tester_present/src/TesterPresent.cpp
@@ -29,6 +29,14 @@ void TesterPresent::handleTesterPresent(uint32_t can_id, std::vector<uint8_t> da
     {
         LOG_ERROR(logger->GET_LOGGER(), "Incorrect message length");
         this->generate->negativeResponse(can_id, 0x3E, 0x13);
+        uint8_t receiver_id = can_id & 0xFF;
+        if (receiver_id == 0x10)
+        {
+            MCU::mcu->stop_flags[0x3E] = false;
+        } else if (receiver_id == 0x11)
+        {
+            battery->stop_flags[0x3E] = false;
+        }
         return;
     }
 
@@ -38,6 +46,14 @@ void TesterPresent::handleTesterPresent(uint32_t can_id, std::vector<uint8_t> da
     {
         LOG_ERROR(logger->GET_LOGGER(), "Sub-function not supported");
         this->generate->negativeResponse(can_id, 0x3E, 0x12);
+                uint8_t receiver_id = can_id & 0xFF;
+        if (receiver_id == 0x10)
+        {
+            MCU::mcu->stop_flags[0x3E] = false;
+        } else if (receiver_id == 0x11)
+        {
+            battery->stop_flags[0x3E] = false;
+        }
         return;
     }
 

--- a/src/uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp
+++ b/src/uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp
@@ -2,6 +2,60 @@
 #include "../../../ecu_simulation/BatteryModule/include/BatteryModule.h"
 #include "../../../mcu/include/MCUModule.h"
 
+/* Helper function to load data from a file into a map */
+std::unordered_map<uint16_t, std::vector<uint8_t>> loadDataFromFile(const std::string& file_name)
+{
+    std::unordered_map<uint16_t, std::vector<uint8_t>> data_map;
+    std::ifstream infile(file_name);
+    if (!infile.is_open())
+    {
+        throw std::runtime_error("Failed to open file: " + file_name);
+    }
+
+    std::string line;
+    while (std::getline(infile, line))
+    {
+        std::istringstream iss(line);
+        uint16_t data_identifier;
+        iss >> std::hex >> data_identifier;
+
+        std::vector<uint8_t> data;
+        int byte;
+        while (iss >> std::hex >> byte)
+        {
+            data.push_back(static_cast<uint8_t>(byte));
+        }
+        data_map[data_identifier] = data;
+    }
+
+    infile.close();
+    return data_map;
+}
+
+/* Helper function to save data from a map to a file */
+void saveDataToFile(const std::string& file_name, const std::unordered_map<uint16_t, std::vector<uint8_t>>& data_map)
+{
+    /* Open in truncate mode to overwrite the file */
+    std::ofstream outfile(file_name, std::ios::trunc);
+
+    if (!outfile.is_open())
+    {
+        throw std::runtime_error("Failed to open file: " + file_name);
+    }
+
+    for (const auto& [data_identifier, data] : data_map)
+    {
+        outfile << std::hex << std::setw(4) << std::setfill('0') << std::uppercase << data_identifier << " ";
+        for (uint8_t byte : data)
+        {
+            outfile << std::hex << std::setw(2) << std::setfill('0') << std::uppercase << static_cast<int>(byte) << " ";
+        }
+        outfile << "\n";
+    }
+
+    outfile.close();
+}
+
 WriteDataByIdentifier::WriteDataByIdentifier(Logger& wdbi_logger, int socket)
             : generate_frames(socket, wdbi_logger), wdbi_logger(wdbi_logger)
 {   
@@ -17,7 +71,6 @@ void WriteDataByIdentifier::WriteDataByIdentifierService(canid_t frame_id, std::
     LOG_INFO(wdbi_logger.GET_LOGGER(), "Write Data By Identifier Service invoked.");
 
     std::vector<uint8_t> response;
-    std::vector<uint8_t> data_parameter = {};
     NegativeResponse nrc(socket, wdbi_logger);
 
     /* Form the new id */
@@ -26,11 +79,27 @@ void WriteDataByIdentifier::WriteDataByIdentifierService(canid_t frame_id, std::
     /* Checks if frame_data has the required minimum length */
     if (frame_data.size() < 3)
     {
-        nrc.sendNRC(id,WDBI_SID,NegativeResponse::IMLOIF);
+        nrc.sendNRC(id, WDBI_SID, NegativeResponse::IMLOIF);
+        uint8_t receiver_id = frame_id & 0xFF;
+        if (receiver_id == 0x10)
+        {
+            MCU::mcu->stop_flags[0x2E] = false;
+        } else if (receiver_id == 0x11)
+        {
+            battery->stop_flags[0x2E] = false;
+        }
     }
     else if (!SecurityAccess::getMcuState())
     {
-        nrc.sendNRC(id,WDBI_SID,NegativeResponse::SAD);
+        nrc.sendNRC(id, WDBI_SID, NegativeResponse::SAD);
+        uint8_t receiver_id = frame_id & 0xFF;
+        if (receiver_id == 0x10)
+        {
+            MCU::mcu->stop_flags[0x2E] = false;
+        } else if (receiver_id == 0x11)
+        {
+            battery->stop_flags[0x2E] = false;
+        }
     }
     else
     {
@@ -40,10 +109,6 @@ void WriteDataByIdentifier::WriteDataByIdentifierService(canid_t frame_id, std::
         /* Extract Data Identifier (DID) */
         DID did = (frame_data[2] << 8) | frame_data[3];
 
-        /* Extract Data Parameter */
-        DataParameter data_parameter(frame_data.begin() + 4, frame_data.end());
-        uint8_t receiver_id = frame_id & 0xFF;
-
         /* List of valid DIDs */
         std::unordered_set<uint16_t> valid_dids = {
             0xF190, 0xF17F, 0xF18C, 0xF1A0, 0xF187, 0xF1A2, 0xF1A1, 0xF1A4, 
@@ -52,74 +117,69 @@ void WriteDataByIdentifier::WriteDataByIdentifierService(canid_t frame_id, std::
             0x0134, 0x0140, 0x01A0, 0x01B0, 0x01C0, 0x00D0, 0x01D0, 0x02D0,
             0x03D0, 0x04D0, 0x05D0, 0x06D0, 0x01E0, 0x01F0
         };
-        auto logCollection = [&](const std::unordered_map<uint16_t, std::vector<uint8_t>>& collection, const std::string& collectionName) {
-            std::ostringstream oss;
-            oss << collectionName << " contents:\n";
-            for (const auto& [key, value] : collection)
-            {
-                oss << "DID 0x" << std::hex << std::setw(4) << std::setfill('0') << key << ": ";
-                for (uint8_t byte : value)
-                {
-                    oss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(byte) << " ";
-                }
-                oss << "\n";
-            }
-            LOG_INFO(wdbi_logger.GET_LOGGER(), oss.str());
-        };
 
-        /* Find where to write the dataParameter */
-        if(receiver_id == 0x10 && MCU::mcu->mcu_data.find(did) != MCU::mcu->mcu_data.end()) 
-        {
-            /* Stores the data in the memory location associated with the DID  */
-            MCU::mcu->mcu_data[did] = data_parameter;
-            LOG_INFO(wdbi_logger.GET_LOGGER(), "Data written to DID 0x{:x} in MCUModule.", did);
-            logCollection(MCU::mcu->mcu_data, "MCUModule");
-        } 
-        else if (receiver_id == 0x11 && battery->ecu_data.find(did) != battery->ecu_data.end()) 
-        {
-            /* Stores the data in the memory location associated with the DID  */
-            battery->ecu_data[did] = data_parameter;
-            LOG_INFO(wdbi_logger.GET_LOGGER(), "Data written to DID 0x{:x} in BatteryModule.", did);
-            logCollection(battery->ecu_data, "BatteryModule");
-        } 
-        else if (valid_dids.find(did) != valid_dids.end())
-        {
-            /* Determine the correct storage based on receiver_id */
-            if (receiver_id == 0x10)
-            {
-                MCU::mcu->mcu_data[did] = data_parameter;
-                LOG_INFO(wdbi_logger.GET_LOGGER(), "Data written to new DID 0x{:x} in MCUModule.", did);
-                logCollection(MCU::mcu->mcu_data, "MCUModule");
-            }
-            else if (receiver_id == 0x11)
-            {
-                battery->ecu_data[did] = data_parameter;
-                LOG_INFO(wdbi_logger.GET_LOGGER(), "Data written to new DID 0x{:x} in BatteryModule.", did);
-                logCollection(battery->ecu_data, "BatteryModule");
-            }
-        }
-        else 
+        if (valid_dids.find(did) == valid_dids.end())
         {
             LOG_ERROR(wdbi_logger.GET_LOGGER(), "Request Out Of Range: Identifier not found in memory");
             nrc.sendNRC(id,WDBI_SID,NegativeResponse::ROOR);
+            uint8_t receiver_id = frame_id & 0xFF;
+            if (receiver_id == 0x10)
+            {
+                MCU::mcu->stop_flags[0x2E] = false;
+            } else if (receiver_id == 0x11)
+            {
+                battery->stop_flags[0x2E] = false;
+            }
+            return;
         }
 
-        switch(receiver_id)
+        /* Extract Data Parameter */
+        DataParameter data_parameter(frame_data.begin() + 4, frame_data.end());
+        uint8_t receiver_id = frame_id & 0xFF;
+
+        std::string file_name;
+        if (receiver_id == 0x10)
         {
-            case 0x10:
-                /* Send response frame */
-                generate_frames.writeDataByIdentifier(id, did, {});
-                LOG_INFO(wdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x2E);
-                MCU::mcu->stop_flags[0x2E] = false;
-                break;
-            case 0x11:
-                /* Send response frame */
-                generate_frames.writeDataByIdentifier(id, did, {});
-                LOG_INFO(wdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x2E);
-                battery->stop_flags[0x2E] = false;
-                break;
-            default:
-                LOG_ERROR(wdbi_logger.GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);
+            file_name = "mcu_data.txt";
+        } else if (receiver_id == 0x11)
+        {
+            file_name = "battery_data.txt";
+        } 
+        else
+        {
+            LOG_ERROR(wdbi_logger.GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);
+            nrc.sendNRC(id, WDBI_SID, NegativeResponse::ROOR);
+            return;
+        }
+
+        try
+        {
+            /* Load current data from the file */
+            auto data_map = loadDataFromFile(file_name);
+
+            // Update or add the new data for the given DID
+            data_map[did] = data_parameter;
+
+            /* Save the updated data back to the file */
+            saveDataToFile(file_name, data_map);
+
+            LOG_INFO(wdbi_logger.GET_LOGGER(), "Data written to DID 0x{:x} in {}.", did, (receiver_id == 0x10 ? "MCUModule" : "BatteryModule"));
+        } catch (const std::exception& e) 
+        {
+            LOG_ERROR(wdbi_logger.GET_LOGGER(), "Error processing file: {}", e.what());
+            nrc.sendNRC(id, WDBI_SID, NegativeResponse::ROOR);
+            return;
+        }
+
+        /* Send response frame */
+        generate_frames.writeDataByIdentifier(id, did, {});
+        LOG_INFO(wdbi_logger.GET_LOGGER(), "Service with SID {:x} successfully sent the response frame.", 0x2E);
+        if (receiver_id == 0x10)
+        {
+            MCU::mcu->stop_flags[0x2e] = false;
+        } else if (receiver_id == 0x11)
+        {
+            battery->stop_flags[0x2e] = false;
         }
     }
 };

--- a/src/utils/src/NegativeResponse.cpp
+++ b/src/utils/src/NegativeResponse.cpp
@@ -46,5 +46,12 @@ void NegativeResponse::sendNRC(int id, uint8_t sid, uint8_t nrc)
 {
     GenerateFrames generate_frames(socket, nrc_logger);
     generate_frames.negativeResponse(id, sid, nrc);
-    LOG_ERROR(nrc_logger.GET_LOGGER(), fmt::format(getDescription(nrc) + " for requested service with SID 0x{:x}",sid));
+    if(nrc != 0x78)
+    {
+        LOG_ERROR(nrc_logger.GET_LOGGER(), fmt::format(getDescription(nrc) + " for requested service with SID 0x{:x}",sid));
+    }
+    else
+    {
+        LOG_WARN(nrc_logger.GET_LOGGER(), fmt::format(getDescription(nrc) + " for requested service with SID 0x{:x}",sid));
+    }
 }


### PR DESCRIPTION
Modify the WriteDataByIdentifier, ReadDataByIdentifier and RequestStatusExit services to write and read data from a file instead of a vector as it is currently implemented.

## Trello link [here](https://trello.com/c/V4cGEbvA/34-change-wdbi-rdbi-to-write-read-did-information-from-a-file)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
