### PR TITLE
Create one ReceiveFrames class for all ECUs

### DIFF
--- a/src/ecu_simulation/BatteryModule/Makefile
+++ b/src/ecu_simulation/BatteryModule/Makefile
@@ -31,20 +31,20 @@ OBJ_DIR = obj
 # Object files
 BATTERY_OBJS = $(OBJ_DIR)/main.o \
 			   $(OBJ_DIR)/BatteryModule.o \
-			   $(OBJ_DIR)/HandleFrames.o \
-			   $(OBJ_DIR)/ReceiveFrames.o
+			   $(OBJ_DIR)/HandleFrames.o 
 
 # MCU object files
 MCU_OBJS = $(OBJ_DIR)/MCUModule.o \
 		   $(OBJ_DIR)/MCUModule_HandleFrames.o \
-		   $(OBJ_DIR)/MCUModule_ReceiveFrames.o \
+		   $(OBJ_DIR)/MCUModule_ReceiveFrames.o 
 		   
 # Utils object files
 UTILS_OBJS = $(OBJ_DIR)/MemoryManager.o \
              $(OBJ_DIR)/Logger.o \
              $(OBJ_DIR)/GenerateFrames.o \
              $(OBJ_DIR)/CreateInterface.o \
-             $(OBJ_DIR)/NegativeResponse.o
+             $(OBJ_DIR)/NegativeResponse.o \
+			 $(OBJ_DIR)/ReceiveFrames.o
 
 # UDS object files
 UDS_OBJS = $(OBJ_DIR)/DiagnosticSessionControl.o \
@@ -109,8 +109,8 @@ $(OBJ_DIR)/CreateInterface.o: $(UTILS_DIR)/CreateInterface.cpp
 $(OBJ_DIR)/DiagnosticSessionControl.o: $(UDS_DIR)/diagnostic_session_control/src/DiagnosticSessionControl.cpp
 	$(CXX) $(CFLAGS) -c $(UDS_DIR)/diagnostic_session_control/src/DiagnosticSessionControl.cpp -o $(OBJ_DIR)/DiagnosticSessionControl.o
 
-$(OBJ_DIR)/ReceiveFrames.o: $(SRC_DIR)/ReceiveFrames.cpp
-	$(CXX) $(CFLAGS) -c $(SRC_DIR)/ReceiveFrames.cpp -o $(OBJ_DIR)/ReceiveFrames.o
+$(OBJ_DIR)/ReceiveFrames.o: $(UTILS_DIR)/ReceiveFrames.cpp
+	$(CXX) $(CFLAGS) -c $(UTILS_DIR)/ReceiveFrames.cpp -o $(OBJ_DIR)/ReceiveFrames.o
 
 $(OBJ_DIR)/ReadDataByIdentifier.o: $(UDS_DIR)/read_data_by_identifier/src/ReadDataByIdentifier.cpp
 	$(CXX) $(CFLAGS) -c $(UDS_DIR)/read_data_by_identifier/src/ReadDataByIdentifier.cpp -o $(OBJ_DIR)/ReadDataByIdentifier.o
@@ -175,13 +175,13 @@ MCU_OBJS_TEST = $(OBJ_DIR)/MCUModule_test.o \
 
 BATTERY_OBJS_TEST = $(OBJ_DIR)/BatteryModule_test.o \
                     $(OBJ_DIR)/HandleFrames_test.o \
-                    $(OBJ_DIR)/ReceiveFrames_test.o
 
 UTILS_OBJS_TEST = $(OBJ_DIR)/MemoryManager_test.o \
                   $(OBJ_DIR)/Logger_test.o \
                   $(OBJ_DIR)/CreateInterface_test.o \
                   $(OBJ_DIR)/GenerateFrames_test.o \
-                  $(OBJ_DIR)/NegativeResponse_test.o
+                  $(OBJ_DIR)/NegativeResponse_test.o \
+				  $(OBJ_DIR)/ReceiveFrames_test.o
 
 OBJS_GENERATE_TEST = $(OBJ_DIR)/Logger_test.o \
                   	 $(OBJ_DIR)/GenerateFrames_test.o
@@ -289,8 +289,8 @@ $(OBJ_DIR)/CreateInterface_test.o: $(UTILS_DIR)/CreateInterface.cpp
 $(OBJ_DIR)/DiagnosticSessionControl_test.o: $(UDS_DIR)/diagnostic_session_control/src/DiagnosticSessionControl.cpp
 	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UDS_DIR)/diagnostic_session_control/src/DiagnosticSessionControl.cpp -o $(OBJ_DIR)/DiagnosticSessionControl_test.o $(CFLAGSTST2) $(LDFLAGS)
 
-$(OBJ_DIR)/ReceiveFrames_test.o: $(SRC_DIR)/ReceiveFrames.cpp
-	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(SRC_DIR)/ReceiveFrames.cpp -o $(OBJ_DIR)/ReceiveFrames_test.o $(CFLAGSTST2) $(LDFLAGS)
+$(OBJ_DIR)/ReceiveFrames_test.o: $(UTILS_DIR)/ReceiveFrames.cpp
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UTILS_DIR)/ReceiveFrames.cpp -o $(OBJ_DIR)/ReceiveFrames_test.o $(CFLAGSTST2) $(LDFLAGS)
 
 $(OBJ_DIR)/ReadDataByIdentifier_test.o: $(UDS_DIR)/read_data_by_identifier/src/ReadDataByIdentifier.cpp
 	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UDS_DIR)/read_data_by_identifier/src/ReadDataByIdentifier.cpp -o $(OBJ_DIR)/ReadDataByIdentifier_test.o $(CFLAGSTST2) $(LDFLAGS)

--- a/src/ecu_simulation/BatteryModule/include/BatteryModule.h
+++ b/src/ecu_simulation/BatteryModule/include/BatteryModule.h
@@ -27,7 +27,7 @@
 #include <future>
 #include <fstream>
 #include "../../../utils/include/CreateInterface.h"
-#include "ReceiveFrames.h"
+#include "../../../utils/include/ReceiveFrames.h"
 #include "../../../utils/include/GenerateFrames.h"
 #include "BatteryModuleLogger.h"
 

--- a/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
+++ b/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
@@ -37,7 +37,7 @@ BatteryModule::BatteryModule() : moduleId(0x11),
 
     battery_socket = canInterface->createSocket(0x00);
     /* Initialize the Frame Receiver */
-    frameReceiver = new ReceiveFrames(battery_socket, moduleId);
+    frameReceiver = new ReceiveFrames(battery_socket, moduleId, *batteryModuleLogger);
 
     LOG_INFO(batteryModuleLogger->GET_LOGGER(), "Battery object created successfully, ID : 0x{:X}", this->moduleId);
 
@@ -73,7 +73,7 @@ BatteryModule::BatteryModule(int _interfaceNumber, int _moduleId) : moduleId(_mo
 
     battery_socket = canInterface->createSocket(0x00);
     /* Initialize the Frame Receiver */
-    frameReceiver = new ReceiveFrames(battery_socket, moduleId);
+    frameReceiver = new ReceiveFrames(battery_socket, moduleId, *batteryModuleLogger);
 
     LOG_INFO(batteryModuleLogger->GET_LOGGER(), "Battery object created successfully using Parameterized Constructor, ID : 0x{:X}", this->moduleId);
 

--- a/src/mcu/Makefile
+++ b/src/mcu/Makefile
@@ -37,15 +37,15 @@ MCU_OBJS = $(OBJ_DIR)/main.o \
 
 # Battery object files
 BATTERY_OBJS = $(OBJ_DIR)/BatteryModule.o \
-               $(OBJ_DIR)/BatteryModule_HandleFrames.o \
-               $(OBJ_DIR)/BatteryModule_ReceiveFrames.o
+               $(OBJ_DIR)/BatteryModule_HandleFrames.o 
 
 # Utils object files
 UTILS_OBJS = $(OBJ_DIR)/MemoryManager.o \
              $(OBJ_DIR)/Logger.o \
              $(OBJ_DIR)/GenerateFrames.o \
              $(OBJ_DIR)/CreateInterface.o \
-             $(OBJ_DIR)/NegativeResponse.o
+             $(OBJ_DIR)/NegativeResponse.o \
+			 $(OBJ_DIR)/BatteryModule_ReceiveFrames.o
 
 # UDS object files
 UDS_OBJS = $(OBJ_DIR)/DiagnosticSessionControl.o \
@@ -128,8 +128,8 @@ $(OBJ_DIR)/TesterPresent.o: $(UDS_DIR)/tester_present/src/TesterPresent.cpp
 $(OBJ_DIR)/BatteryModule_HandleFrames.o: $(BATTERY_DIR)/HandleFrames.cpp
 	$(CXX) $(CFLAGS) -c $(BATTERY_DIR)/HandleFrames.cpp -o $(OBJ_DIR)/BatteryModule_HandleFrames.o
 
-$(OBJ_DIR)/BatteryModule_ReceiveFrames.o: $(BATTERY_DIR)/ReceiveFrames.cpp
-	$(CXX) $(CFLAGS) -c $(BATTERY_DIR)/ReceiveFrames.cpp -o $(OBJ_DIR)/BatteryModule_ReceiveFrames.o
+$(OBJ_DIR)/BatteryModule_ReceiveFrames.o: $(UTILS_DIR)/ReceiveFrames.cpp
+	$(CXX) $(CFLAGS) -c $(UTILS_DIR)/ReceiveFrames.cpp -o $(OBJ_DIR)/BatteryModule_ReceiveFrames.o
 
 $(OBJ_DIR)/ReadDtcInformation.o: $(UDS_DIR)/read_dtc_information/src/ReadDtcInformation.cpp
 	$(CXX) $(CFLAGS) -c $(UDS_DIR)/read_dtc_information/src/ReadDtcInformation.cpp -o $(OBJ_DIR)/ReadDtcInformation.o

--- a/src/mcu/src/ReceiveFrames.cpp
+++ b/src/mcu/src/ReceiveFrames.cpp
@@ -396,7 +396,8 @@ bool ReceiveFrames::receiveFramesFromAPI()
                             ecus_up[i] = 0;
                         }/* Send request frame */
                         std::vector<uint8_t> data = {0x01};
-                        ReceiveFrames::generate_frames.sendFrame(0x1011, data);
+                        uint16_t id = (0x10 << 8) | it->first;
+                        ReceiveFrames::generate_frames.sendFrame(id, data);
                         it = ecu_timers.erase(it);
                     } else {
                         ++it;

--- a/src/uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp
+++ b/src/uds/diagnostic_session_control/src/DiagnosticSessionControl.cpp
@@ -57,10 +57,12 @@ void DiagnosticSessionControl::sessionControl(canid_t frame_id, uint8_t sub_func
 /* Method to switch current session to Default Session */
 void DiagnosticSessionControl::switchToDefaultSession(canid_t frame_id)
 {
+    LOG_INFO(dsc_logger->GET_LOGGER(), "Session before change: {}", getCurrentSessionToString());
+
     /* Switch to Default Session */
     current_session = DEFAULT_SESSION;
 
-    LOG_INFO(dsc_logger->GET_LOGGER(), "Switched to Default Session. Current session: {}", getCurrentSessionToString());
+    LOG_INFO(dsc_logger->GET_LOGGER(), "Current session: {}", getCurrentSessionToString());
 
     /* Create instance of Generate Frames to send response frame */
     GenerateFrames response_frame(socket, *dsc_logger);
@@ -96,10 +98,12 @@ void DiagnosticSessionControl::switchToDefaultSession(canid_t frame_id)
 /* Method to switch current session to Programming Session */
 void DiagnosticSessionControl::switchToProgrammingSession(canid_t frame_id)
 {
+    
+    LOG_INFO(dsc_logger->GET_LOGGER(), "Session before change: {}", getCurrentSessionToString());
     /* Switch to Programming Session */
     current_session = PROGRAMMING_SESSION;
 
-    LOG_INFO(dsc_logger->GET_LOGGER(), "Switched to Programming Session. Current session: {}", getCurrentSessionToString());
+    LOG_INFO(dsc_logger->GET_LOGGER(), "Current session: {}", getCurrentSessionToString());
 
     /* Create instance of Generate Frames to send response frame */
     GenerateFrames response_frame(socket, *dsc_logger);


### PR DESCRIPTION
I modified the ReceiveFrames class in the BatteryModule to make it usable by all ECUs

## Trello link [here](https://trello.com/c/xvgyyWUX/32-create-one-receive-class-for-all-modules)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
