### PR TITLE
Negative responses scenarios for existing SID's

### DIFF
--- a/src/rest_api/actions/manual_send_frame.py
+++ b/src/rest_api/actions/manual_send_frame.py
@@ -77,6 +77,18 @@ def handle_negative_response(nrc, service_id):
 
         # Access Timing Parameter Service (0x83)
         0x83: {0x12, 0x13, 0x78},
+
+        # Clear Diagnostic Information (0x14)
+        0x14: {0x13, 0x31},
+
+        # Read DTC Information (0x19)
+        0x19: {0x12, 0x13},
+
+        # Routine Control (0x31)
+        0x31: {0x12, 0x31},
+
+        # Tester Present (0x3E)
+        0x3E: {0x12, 0x13}
     }
 
     # General negative response codes

--- a/src/rest_api/actions/manual_send_frame.py
+++ b/src/rest_api/actions/manual_send_frame.py
@@ -19,7 +19,7 @@ def manual_send_frame(can_id, can_data):
 
         message = can.Message(arbitration_id=can_id, data=can_data, is_extended_id=True)
         bus.send(message)
-        received_frame = bus.recv(timeout=15)
+        received_frame = bus.recv(timeout=35)
 
         if received_frame is not None:
             received_data = {
@@ -27,24 +27,27 @@ def manual_send_frame(can_id, can_data):
                 'can_data': [hex(byte) for byte in received_frame.data]
             }
 
+            # Authentication success case
             if received_frame.data[1] == 0x67 and \
-                received_frame.data[2] == 0x01 and \
-                    received_frame.data[3] == 0x00 or \
-                    received_frame.data[1] == 0x67 and received_frame.data[2] == 0x02:
+                (received_frame.data[2] in {0x01, 0x02}) and \
+                    received_frame.data[3] == 0x00:
                 log_info_message(logger, "Authentication successful")
                 received_data['auth_status'] = 'success'
 
-            if received_frame.data[1] == 0x7F:  # Diagnostic negative response
+            # Handle negative response codes
+            elif received_frame.data[1] == 0x7F:
                 nrc = received_frame.data[3]
-                if nrc == 0x37:
+                service_id = received_frame.data[2]
+                error_text = handle_negative_response(nrc, service_id)
+
+                received_data['auth_status'] = 'failed'
+                received_data['error_text'] = error_text
+
+                if nrc == 0x37:  # Specific handling for "RequiredTimeDelayNotExpired"
                     time_delay_ms = int.from_bytes(received_frame.data[4:8], byteorder='big')
                     time_delay_s = time_delay_ms / 1000
-                    log_info_message(logger, f"Retries exceeded. Try again in : {time_delay_s} s")
+                    log_info_message(logger, f"Retries exceeded. Try again in: {time_delay_s} s")
                     received_data['retry_timeout_ms'] = time_delay_ms
-                else:
-                    error_text = handle_negative_response(received_frame.data)
-                    received_data['auth_status'] = 'failed'
-                    received_data['error_text'] = error_text
         else:
             received_data = None
 
@@ -58,19 +61,42 @@ def manual_send_frame(can_id, can_data):
         bus.shutdown()
 
 
-def handle_negative_response(frame_response):
+def handle_negative_response(nrc, service_id):
     """
-    Handles the negative response scenarios.
+    Handles the negative response scenarios for various services.
     """
+    service_error_mapping = {
+        # Write Data by Identifier (0x2E)
+        0x2E: {0x13, 0x31, 0x33},
+
+        # Security Access (0x27)
+        0x27: {0x12, 0x24, 0x35, 0x36},
+
+        # Diagnostic Session Control Service (0x10)
+        0x10: {0x12},
+
+        # Access Timing Parameter Service (0x83)
+        0x83: {0x12, 0x13, 0x78},
+    }
+
+    # General negative response codes
     negative_responses = {
         0x12: "SubFunctionNotSupported",
         0x13: "IncorrectMessageLengthOrInvalidFormat",
         0x24: "RequestSequenceError",
+        0x31: "RequestOutOfRange",
+        0x33: "SecurityAccessDenied",
         0x35: "InvalidKey",
         0x36: "ExceededNumberOfAttempts",
-        0x37: "RequiredTimeDelayNotExpired"
+        0x37: "RequiredTimeDelayNotExpired",
+        0x78: "ResponsePending"
     }
-    nrc = frame_response[3]
-    error_message = negative_responses.get(nrc, "Unknown error")
-    log_error_message(logger, f"Authentication failed: {error_message}")
+
+    # Check if the NRC is within the allowed list for the service
+    if service_id in service_error_mapping and nrc in service_error_mapping[service_id]:
+        error_message = negative_responses.get(nrc, "Unknown error")
+    else:
+        error_message = "Unknown service or error"
+
+    log_error_message(logger, f"Authentication failed: {error_message} (Code: {hex(nrc)})")
     return error_message


### PR DESCRIPTION
## Description

Introduces support for the code to process and report negative response for the following services:

- Write Data by Identifier (0x2E)
- Security Access (0x27)
- Diagnostic Session Control (0x10)
- Access Timing Parameter Service (0x83)
- Clear Diagnostic Information (0x14)
- Read DTC Information (0x19)
- Routine Control (0x31)
- Tester Present (0x3E)

## Trello link [here](https://trello.com/c/hBbjBWZv/60-follow-up-negative-responses-scenarios-for-existing-sids)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
