### PR TITLE
small fix for readDtc

### DIFF
--- a/src/autoscripts/start_simulation.sh
+++ b/src/autoscripts/start_simulation.sh
@@ -34,7 +34,7 @@ echo "Navigated to ../mcu" &&
     echo "Cleaned the MCUModule build" &&
     make &&
     echo "Compiled the MCU application" &&
-    ./main &&
+    ./main_mcu &&
     echo "Ran the MCU application"
 } 2>&1 | tee mcu_log.txt &&
 exec bash
@@ -48,7 +48,7 @@ make clean &&
 echo "Cleaned the BatteryModule build" &&
 make &&
 echo "Compiled the BatteryModule application" &&
-./main &&
+./main_battery &&
 echo "Ran the BatteryModule application" &&
 exec bash
 '

--- a/src/uds/read_dtc_information/src/ReadDtcInformation.cpp
+++ b/src/uds/read_dtc_information/src/ReadDtcInformation.cpp
@@ -107,8 +107,8 @@ void ReadDTC::number_of_dtc(int id, int dtc_status_mask)
     /* dtc format_idtf 0x01 -> ISO_14229-1_DTCFormat */
     int dtc_format_identifier = 0x01;
 
-    uint8_t lowerbits = id & 0xFF;
-    switch(lowerbits)
+    uint8_t receiver_id = id >> 8 & 0xFF;
+    switch(receiver_id)
     {
         case 0x10:
             /* Send response frame */
@@ -123,7 +123,7 @@ void ReadDTC::number_of_dtc(int id, int dtc_status_mask)
             battery->stop_flags[0x19] = false;
             break;
         default:
-            LOG_ERROR(logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
+            LOG_ERROR(logger.GET_LOGGER(), "Module with id {:x} not supported.", receiver_id);
     }
 }
 
@@ -174,38 +174,38 @@ void ReadDTC::report_dtcs(int id, int dtc_status_mask)
     /* Send a frame/frames with all dtcs founded */
     if (dtc_and_status_list.size() > 1)
     {   
-        uint8_t lowerbits = id & 0xFF;
+        uint8_t lowerbits = id >> 8 & 0xFF;
         switch(lowerbits)
         {
             case 0x10:
                 /* Send response frame */
                 this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,true);
+                this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,false);
                 LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the first response frame.", 0x19);
                 MCU::mcu->stop_flags[0x19] = false;
                 break;
             case 0x11:
                 /* Send response frame */
                 this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,true);
+                this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,false);
                 LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent the first response frame.", 0x19);
                 battery->stop_flags[0x19] = false;
                 break;
             default:
                 LOG_ERROR(logger.GET_LOGGER(), "Module with id {:x} not supported.", lowerbits);
         }
-
+/** flow control frame not implemented yet -> uncomment this when ready
         if (receive_flow_control(id / 0x100))
         {
             uint8_t lowerbits = id & 0xFF;
             switch(lowerbits)
             {
                 case 0x10:
-                    /* Send response frame */
                     this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,false);
                     LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent a consecutive response frame.", 0x19);
                     MCU::mcu->stop_flags[0x19] = false;
                     break;
                 case 0x11:
-                    /* Send response frame */
                     this->generate->readDtcInformationResponse02Long(id,status_availability_mask,dtc_and_status_list,false);
                     LOG_INFO(logger.GET_LOGGER(), "Service with SID {:x} successfully sent a consecutive response frame.", 0x19);
                     battery->stop_flags[0x19] = false;
@@ -218,11 +218,12 @@ void ReadDTC::report_dtcs(int id, int dtc_status_mask)
         else
         {
             LOG_ERROR(logger.GET_LOGGER(), "Timeout. FLow control frame not received!");
-        }
+        } 
+*/
     }
     else 
     {
-        uint8_t lowerbits = id & 0xFF;
+        uint8_t lowerbits = id >> 8 & 0xFF;
         switch(lowerbits)
         {
             case 0x10:


### PR DESCRIPTION
## Description

Removed flow control frame check and reversed receiver_id.
Also updated start_simulation.sh script because binary files' name changed.

## Trello link [here](https://trello.com/c/eHZfcbVk/37-fix-readdtc)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
