### PR TITLE
Updated IPC logic

### DIFF
--- a/src/ecu_simulation/BatteryModule/src/main.cpp
+++ b/src/ecu_simulation/BatteryModule/src/main.cpp
@@ -10,7 +10,7 @@ int main() {
     battery->fetchBatteryData();
     std::thread receiveFrThread([]()
                                { battery->receiveFrames(); });
-    sleep(200);
+    sleep(2000);
     battery->stopFrames();
     receiveFrThread.join();
     return 0;

--- a/src/mcu/include/ReceiveFrames.h
+++ b/src/mcu/include/ReceiveFrames.h
@@ -274,6 +274,16 @@ namespace MCU
      * @return int 
      */
     int getMcuSocket(uint8_t sender_id);
+    /**
+     * @brief Notify each ECU that the MCU state is unlocked.
+     * This method sends a notification frame to multiple ECUs (Battery, Engine, Doors, HVAC)
+     * indicating that the MCU state is unlocked. It appends the necessary data to the provided
+     * response vector and uses the class's generate_frames attribute to send the frames.
+     * 
+     * @param[in] response vector containing the data to be sent in each frame.
+     */
+    void securityNotifyECU(std::vector<uint8_t> response);
+
   };
 }
 #endif /* POC_SRC_MCU_RECEIVE_FRAME_MODULE_H */

--- a/src/mcu/src/ReceiveFrames.cpp
+++ b/src/mcu/src/ReceiveFrames.cpp
@@ -232,7 +232,7 @@ bool ReceiveFrames::receiveFramesFromAPI()
                         /* Receiver HVAC */
                         upperbits = 0x14;
                         generate_frames.sendFrame((lowerbits << 8) | upperbits,response,DATA_FRAME);
-                        LOG_INFO(MCULogger->GET_LOGGER(), "Server is locked.");
+                        LOG_INFO(MCULogger->GET_LOGGER(), "Server is unlocked.");
                     }
                 }
             }

--- a/src/uds/authentication/include/SecurityAccess.h
+++ b/src/uds/authentication/include/SecurityAccess.h
@@ -33,7 +33,7 @@ class SecurityAccess
     /* Adjust nr of attempts here. */
     static constexpr uint8_t MAX_NR_OF_ATTEMPTS = 3;
     /* Adjust timer until security access will expire here. */
-    static constexpr uint8_t SECURITY_TIMEOUT_IN_SECONDS = 0x0A;
+    static constexpr uint8_t SECURITY_TIMEOUT_IN_SECONDS = 0x1E;
 
     private:
         GenerateFrames* generate_frames;

--- a/src/uds/authentication/include/SecurityAccess.h
+++ b/src/uds/authentication/include/SecurityAccess.h
@@ -32,8 +32,10 @@ class SecurityAccess
     static constexpr uint8_t TIMEOUT_IN_SECONDS = 0x05;
     /* Adjust nr of attempts here. */
     static constexpr uint8_t MAX_NR_OF_ATTEMPTS = 3;
-    /* Adjust timer until security access will expire here. */
-    static constexpr uint8_t SECURITY_TIMEOUT_IN_SECONDS = 0x1E;
+    /* Adjust timer until security access will expire here. 
+     * Now it's set to 180 seconds.
+    */
+    static constexpr uint8_t SECURITY_TIMEOUT_IN_SECONDS =  0xB4;
 
     private:
         GenerateFrames* generate_frames;

--- a/src/uds/authentication/src/SecurityAccess.cpp
+++ b/src/uds/authentication/src/SecurityAccess.cpp
@@ -218,23 +218,6 @@ void SecurityAccess::securityAccess(canid_t can_id, const std::vector<uint8_t>& 
                         LOG_INFO(security_logger.GET_LOGGER(), "Security Access granted successfully.");
                         mcu_state = true;
                         response.clear();
-                        /* Create a frame to notify each ECU that MCU state is unlocked */
-                        response.push_back(0x01);
-                        response.push_back(0xCE);
-                        /* Set sender to MCU ID */
-                        lowerbits = 0x10;
-                        /* Receiver battery */
-                        upperbits = 0x11;
-                        generate_frames_ECU.sendFrame((lowerbits << 8) | upperbits,response,DATA_FRAME);
-                        /* Receiver engine */
-                        upperbits = 0x12;
-                        generate_frames_ECU.sendFrame((lowerbits << 8) | upperbits,response,DATA_FRAME);
-                        /* Receiver doors */
-                        upperbits = 0x13;
-                        generate_frames_ECU.sendFrame((lowerbits << 8) | upperbits,response,DATA_FRAME);
-                        /* Receiver HVAC */
-                        upperbits = 0x14;
-                        generate_frames_ECU.sendFrame((lowerbits << 8) | upperbits,response,DATA_FRAME);
                         end_time_security = std::chrono::steady_clock::now() +
                                     std::chrono::seconds(SECURITY_TIMEOUT_IN_SECONDS);
                         auto security_now = std::chrono::steady_clock::now();

--- a/src/uds/authentication/src/SecurityAccess.cpp
+++ b/src/uds/authentication/src/SecurityAccess.cpp
@@ -165,9 +165,9 @@ void SecurityAccess::securityAccess(canid_t can_id, const std::vector<uint8_t>& 
             {
                 /* Adjust the seed length between 1 and 5.*/
                 std::srand(static_cast<uint8_t>(std::time(nullptr)));
-                size_t seed_length = 1;//std::rand() % 5 + 1;
+                size_t seed_length = std::rand() % 5 + 1;
 
-                std::vector<uint8_t> seed = {0xCB};//generateRandomBytes(seed_length);
+                std::vector<uint8_t> seed = generateRandomBytes(seed_length);
 
                 /* PCI length = seed_length + 2(0x67 and 0x01)*/
                 response.push_back(static_cast<uint8_t>(2 + seed_length));

--- a/src/uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp
+++ b/src/uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp
@@ -103,8 +103,9 @@ void WriteDataByIdentifier::WriteDataByIdentifierService(canid_t frame_id, std::
     {
         nrc.sendNRC(id, WDBI_SID, NegativeResponse::SAD);
         battery->stop_flags[0x2E] = false;
-        } else if (receiver_id == 0x12)
-        {
+    }
+    else if (receiver_id == 0x12)
+    {
             engine->stop_flags[0x2E] = false;
     }
     else

--- a/src/utils/src/HandleFrames.cpp
+++ b/src/utils/src/HandleFrames.cpp
@@ -150,22 +150,13 @@ void HandleFrames::processFrameData(int can_socket, canid_t frame_id, uint8_t si
         case 0x27:
         {
 
-                /* This service can be called in PROGRAMMING_SESSION */
-                if(DiagnosticSessionControl::getCurrentSessionToString() == "PROGRAMMING_SESSION")
-                {
-                    LOG_INFO(_logger.GET_LOGGER(), "SecurityAccess called.");
-                    SecurityAccess security_access(can_socket,_logger);
-                    security_access.securityAccess(frame_id, frame_data);
-                    if (!SecurityAccess::getMcuState(_logger))
-                    {
-                        LOG_INFO(_logger.GET_LOGGER(), "Server is locked.");
-                    }
-                
-                    else
-                    {
-                        LOG_INFO(_logger.GET_LOGGER(), "Server is locked.");
-                    }
-                }
+            /* This service can be called in PROGRAMMING_SESSION */
+            if(DiagnosticSessionControl::getCurrentSessionToString() == "PROGRAMMING_SESSION")
+            {
+                LOG_INFO(_logger.GET_LOGGER(), "SecurityAccess called.");
+                SecurityAccess security_access(can_socket,_logger);
+                security_access.securityAccess(frame_id, frame_data);
+            }
             else
             {
                 int new_id = ((frame_id & 0xFF) << 8) | ((frame_id >> 8) & 0xFF);

--- a/src/utils/src/HandleFrames.cpp
+++ b/src/utils/src/HandleFrames.cpp
@@ -149,7 +149,6 @@ void HandleFrames::processFrameData(int can_socket, canid_t frame_id, uint8_t si
         }
         case 0x27:
         {
-
             /* This service can be called in PROGRAMMING_SESSION */
             if(DiagnosticSessionControl::getCurrentSessionToString() == "PROGRAMMING_SESSION")
             {

--- a/src/utils/src/ReceiveFrames.cpp
+++ b/src/utils/src/ReceiveFrames.cpp
@@ -193,6 +193,7 @@ void ReceiveFrames::bufferFrameOut(HandleFrames &handle_frame)
                 default:
                     break;
             }
+            goto label1;
         }
 
         /* Check if the frame is a request of type 'Up-Notification' from MCU */

--- a/src/utils/src/ReceiveFrames.cpp
+++ b/src/utils/src/ReceiveFrames.cpp
@@ -172,6 +172,7 @@ void ReceiveFrames::bufferFrameOut(HandleFrames &handle_frame)
             LOG_WARN(receive_logger.GET_LOGGER(), "Invalid CAN ID: upper 8 bits are zero\n");
             return;
         }
+        /* Notify from MCU to tell ECU's that MCU state is unlocked */
         if (frame.data[0] == 0x01 && frame.data[1] == 0xCE)
         {
             LOG_INFO(receive_logger.GET_LOGGER(), "Security Access unlocked.");

--- a/src/utils/src/ReceiveFrames.cpp
+++ b/src/utils/src/ReceiveFrames.cpp
@@ -175,7 +175,7 @@ void ReceiveFrames::bufferFrameOut(HandleFrames &handle_frame)
         /* Notify from MCU to tell ECU's that MCU state is unlocked */
         if (frame.data[0] == 0x01 && frame.data[1] == 0xCE)
         {
-            LOG_INFO(receive_logger.GET_LOGGER(), "Security Access unlocked.");
+            LOG_INFO(receive_logger.GET_LOGGER(), "Notification from the MCU that the server is unlocked.");
             switch(frame_dest_id)
             {
                 case 0x11:
@@ -189,6 +189,29 @@ void ReceiveFrames::bufferFrameOut(HandleFrames &handle_frame)
                     break;
                 case 0x14:
                     hvac_state = true;
+                    break;
+                default:
+                    break;
+            }
+            goto label1;
+        }
+        /* Notify from MCU to tell ECU's that MCU state is locked */
+        else if (frame.data[0] == 0x01 && frame.data[1] == 0xCF)
+        {
+            LOG_INFO(receive_logger.GET_LOGGER(), "Notification from the MCU that the server is locked.");
+            switch(frame_dest_id)
+            {
+                case 0x11:
+                    battery_state = false;
+                    break;
+                case 0x12:
+                    engine_state = false;
+                    break;
+                case 0x13:
+                    doors_state = false;
+                    break;
+                case 0x14:
+                    hvac_state = false;
                     break;
                 default:
                     break;


### PR DESCRIPTION
## Description
Updated IPC:
- Now it is up to date with handle and receive frames reworks(because handleFrames now use one socket only)
- Logic for notify moved from service into receiveframes
- Logic for notify if the security timer expires (0xCE if security is unlocked, 0xCF if security is locked)
- Linked readDatabyIdentifier to IPC
- Now rdbi and wdbi work on battery ECU
- Updated timer flags for security SAD nrc in readDataByIdentifier

## Trello link [here](https://trello.com/c/5v2qphe2/35-implement-ipc-for-securityaccess-for-ecu-battery)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
