### PR TITLE
DTC size format modified

### DIFF
--- a/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
+++ b/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
@@ -303,7 +303,7 @@ void BatteryModule::checkDTC()
     std::unordered_map<uint16_t, std::vector<uint8_t>> current_DID_value = FileManager::readMapFromFile("battery_data.txt");
 
     /* Voltage DTC */
-    FileManager::writeDTC(current_DID_value, dtc_file_path, 0x01B0, 12, 12, "P01B0 24");
+    FileManager::writeDTC(current_DID_value, dtc_file_path, 0x01B0, 12, 13, "P01B0 24");
     /* Temperature DTC */
-    FileManager::writeDTC(current_DID_value, dtc_file_path, 0x01E0, 0, 80, "P01E0 24");
+    FileManager::writeDTC(current_DID_value, dtc_file_path, 0x01E0, 21, 27, "P01E0 24");
 }

--- a/src/ecu_simulation/EngineModule/src/EngineModule.cpp
+++ b/src/ecu_simulation/EngineModule/src/EngineModule.cpp
@@ -190,6 +190,6 @@ void EngineModule::checkDTC()
     /* Engine Load DTC*/
     FileManager::writeDTC(current_DID_value, dtc_file_path, 0x011C, 0, 85, "P0069 24");
     /* Engine Coolant Temperature DTC */
-    FileManager::writeDTC(current_DID_value, dtc_file_path, 0x010C, 195, 220, "P0115 24");
+    FileManager::writeDTC(current_DID_value, dtc_file_path, 0x010C, 90, 105, "P0115 24");
 }
 

--- a/src/utils/src/GenerateFrames.cpp
+++ b/src/utils/src/GenerateFrames.cpp
@@ -399,6 +399,10 @@ void GenerateFrames::readDtcInformationResponse02Long(int id, uint8_t status_ava
     for (std::pair<int, int> dtc_and_status : dtc_and_status_list)
     {
         uint8_t length_dtc_and_status = (countDigits(dtc_and_status.first) +1) / 2;
+        if(length_dtc_and_status > 2)
+        {
+            length_dtc_and_status = 2;
+        }
         insertBytes(data,dtc_and_status.first,length_dtc_and_status);
         data.push_back(dtc_and_status.second);
         pci_l += length_dtc_and_status + 1;


### PR DESCRIPTION
- The first issue was the order in which we opened the file with DTCs.
- The second issue was that the size of a DTC was set larger than it actually was, and it was automatically filled with zeros. This caused incorrect bytes with zeros to be inserted.

## Trello link [here](https://trello.com/c/lS0rG4Zl/18-backendminor-cleardtc)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
