### PR TITLE
Decorator for handling separate security in Read Info 

### DIFF
--- a/src/rest_api/actions/base_actions.py
+++ b/src/rest_api/actions/base_actions.py
@@ -226,7 +226,7 @@ class Action:
 
         return True
 
-    def __algorithm(self, seed: list):
+    def _algorithm(self, seed: list):
         """
         Method to generate a key based on the seed.
         """

--- a/src/rest_api/actions/base_actions.py
+++ b/src/rest_api/actions/base_actions.py
@@ -267,7 +267,7 @@ class Action:
         else:
             # Extract seed and compute key
             seed = self._data_from_frame(frame_response)
-            key = self.__algorithm(seed)
+            key = self._algorithm(seed)
             log_info_message(logger, f"Key: {key}")
 
             # Send the key for authentication

--- a/src/rest_api/actions/read_info_action.py
+++ b/src/rest_api/actions/read_info_action.py
@@ -12,22 +12,6 @@ class ReadInfo(Action):
     - id_ecu: Identifier for the specific ECU being updated.
     - g: Instance of GenerateFrame for generating CAN bus frames.
     """
-    def _auth_mcu(self, ecu_type):
-
-        id_mcu = self.id_ecu[ecu_type]
-        id = self.my_id * 0x100 + id_mcu
-
-        try:
-            log_info_message(logger, "Changing session to programming")
-            self.generate.session_control(id, 0x02)
-            self._passive_response(SESSION_CONTROL, "Error changing session control")
-            id = (self.id_ecu[ecu_type] << 16) + (self.my_id << 8) + self.id_ecu[MCU]
-            self._authentication(id)
-
-        except CustomError as e:
-            self.bus.shutdown()
-            return e.message
-
     @staticmethod
     def _get_battery_state_of_charge(state_of_charge):
         if state_of_charge.startswith("0x"):

--- a/src/rest_api/actions/secure_auth.py
+++ b/src/rest_api/actions/secure_auth.py
@@ -42,7 +42,7 @@ class Auth(Action):
             else:
                 # Extract seed and compute key
                 seed = self._data_from_frame(frame_response)
-                key = self.__algorithm(seed)
+                key = self._algorithm(seed)
                 log_info_message(logger, f"Key: {key}")
 
                 # Send the key for authentication

--- a/src/rest_api/actions/security_decorator.py
+++ b/src/rest_api/actions/security_decorator.py
@@ -1,0 +1,30 @@
+from functools import wraps
+from flask import jsonify
+from actions.secure_auth import Auth
+from actions.diag_session import SessionManager
+from configs.data_identifiers import *
+
+def requires_auth(func):
+    @wraps(func)
+    def decorated_function(*args, **kwargs):
+        try:
+            id = (API_ID << 8) + 0x10 
+
+            session = SessionManager(API_ID)
+            response = session._change_session(id, 2)
+
+            if response["status"] == "error":
+                return jsonify({"error": "Session change failed", "message": response["message"]}), 500
+            
+            auth = Auth(API_ID, [0x10, 0x11, 0x12, 0x13, 0x14]) 
+            auth_response = auth._auth_to()
+
+            if "error" in auth_response:
+                return jsonify({"error": "Authentication failed"}), 403
+            
+            return func(*args, **kwargs)
+
+        except Exception as e:
+            return jsonify({"error": f"An unexpected error occurred: {str(e)}"}), 500
+
+    return decorated_function

--- a/src/rest_api/actions/security_decorator.py
+++ b/src/rest_api/actions/security_decorator.py
@@ -4,27 +4,28 @@ from actions.secure_auth import Auth
 from actions.diag_session import SessionManager
 from configs.data_identifiers import *
 
+
 def requires_auth(func):
     @wraps(func)
     def decorated_function(*args, **kwargs):
         try:
-            id = (API_ID << 8) + 0x10 
+            id = (API_ID << 8) + 0x10
 
             session = SessionManager(API_ID)
             response = session._change_session(id, 2)
 
             if response["status"] == "error":
                 return jsonify({"error": "Session change failed", "message": response["message"]}), 500
-            
-            auth = Auth(API_ID, [0x10, 0x11, 0x12, 0x13, 0x14]) 
+
+            auth = Auth(API_ID, [0x10, 0x11, 0x12, 0x13, 0x14])
             auth_response = auth._auth_to()
 
             if "error" in auth_response:
                 return jsonify({"error": "Authentication failed"}), 403
-            
-            return func(*args, **kwargs)
 
         except Exception as e:
             return jsonify({"error": f"An unexpected error occurred: {str(e)}"}), 500
+
+        return func(*args, **kwargs)
 
     return decorated_function

--- a/src/rest_api/routes/api.py
+++ b/src/rest_api/routes/api.py
@@ -17,7 +17,7 @@ from actions.diag_session import SessionManager  # noqa: E402
 from actions.tester_present import Tester  # noqa: E402
 from actions.access_timing_action import *  # noqa: E402
 from actions.ecu_reset import Reset  # noqa: E402
-from actions.security_decorator import * # noqa: E402
+from actions.security_decorator import *  # noqa: E402
 
 api_bp = Blueprint('api', __name__)
 
@@ -61,7 +61,7 @@ def read_info_eng():
 
 
 @api_bp.route('/read_info_doors', methods=['GET'])
-
+@requires_auth
 def read_info_doors():
     reader = ReadInfo(API_ID, [0x10, 0x11, 0x12, 0x13])
     item = request.args.get('item', default=None, type=str)
@@ -70,7 +70,7 @@ def read_info_doors():
 
 
 @api_bp.route('/read_info_hvac', methods=['GET'])
-
+@requires_auth
 def read_info_hvac():
     reader = ReadInfo(API_ID, [0x10, 0x11, 0x12, 0x13, 0x14])
     item = request.args.get('item', default=None, type=str)

--- a/src/rest_api/routes/api.py
+++ b/src/rest_api/routes/api.py
@@ -17,6 +17,7 @@ from actions.diag_session import SessionManager  # noqa: E402
 from actions.tester_present import Tester  # noqa: E402
 from actions.access_timing_action import *  # noqa: E402
 from actions.ecu_reset import Reset  # noqa: E402
+from actions.security_decorator import * # noqa: E402
 
 api_bp = Blueprint('api', __name__)
 
@@ -42,6 +43,7 @@ def update_to_version():
 
 
 @api_bp.route('/read_info_battery', methods=['GET'])
+@requires_auth
 def read_info_bat():
     reader = ReadInfo(0xFA, [0x10, 0x11, 0x12])
     item = request.args.get('item', default=None, type=str)
@@ -50,6 +52,7 @@ def read_info_bat():
 
 
 @api_bp.route('/read_info_engine', methods=['GET'])
+@requires_auth
 def read_info_eng():
     reader = ReadInfo(API_ID, [0x10, 0x11, 0x12])
     item = request.args.get('item', default=None, type=str)
@@ -58,6 +61,7 @@ def read_info_eng():
 
 
 @api_bp.route('/read_info_doors', methods=['GET'])
+
 def read_info_doors():
     reader = ReadInfo(API_ID, [0x10, 0x11, 0x12, 0x13])
     item = request.args.get('item', default=None, type=str)
@@ -66,6 +70,7 @@ def read_info_doors():
 
 
 @api_bp.route('/read_info_hvac', methods=['GET'])
+
 def read_info_hvac():
     reader = ReadInfo(API_ID, [0x10, 0x11, 0x12, 0x13, 0x14])
     item = request.args.get('item', default=None, type=str)


### PR DESCRIPTION
## Description

Decorator that manages separate security checks for the read_info endpoints. It ensures that the session is changed to programming mode and the user is authenticated before accessing the information.

## Trello link [here](https://trello.com/c/YrljnP1Y/111-read-endpoints-should-not-handle-security)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
