### PR TITLE
Feature/WDBI UT Fixed

### DIFF
--- a/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
+++ b/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
@@ -278,7 +278,8 @@ void BatteryModule::writeDataToFile()
 void BatteryModule::checkDTC()
 {
     /* Check if dtcs.txt exists */
-    std::string dtc_file_path = "dtcs.txt";
+    std::string dtc_file_path = std::string(PROJECT_PATH) + "/src/ecu_simulation/BatteryModule/dtcs.txt";
+    std::string battery_file_path = std::string(PROJECT_PATH) + "/src/ecu_simulation/BatteryModule/battery_data.txt";
     std::ifstream infile(dtc_file_path);
 
     if (!infile.is_open())
@@ -300,7 +301,7 @@ void BatteryModule::checkDTC()
         infile.close();
     }
     /* Read the map with DIDs from the file */
-    std::unordered_map<uint16_t, std::vector<uint8_t>> current_DID_value = FileManager::readMapFromFile("battery_data.txt");
+    std::unordered_map<uint16_t, std::vector<uint8_t>> current_DID_value = FileManager::readMapFromFile(battery_file_path);
 
     /* Voltage DTC */
     FileManager::writeDTC(current_DID_value, dtc_file_path, 0x01B0, 12, 13, "P01B0 24");

--- a/src/ecu_simulation/EngineModule/src/EngineModule.cpp
+++ b/src/ecu_simulation/EngineModule/src/EngineModule.cpp
@@ -159,7 +159,8 @@ void EngineModule::writeDataToFile()
 void EngineModule::checkDTC()
 {      
     /* Check if dtcs.txt exists */
-    std::string dtc_file_path = "dtcs.txt";
+    std::string dtc_file_path = std::string(PROJECT_PATH) + "/src/ecu_simulation/EngineModule/dtcs.txt";
+    std::string engine_file_path = std::string(PROJECT_PATH) + "/src/ecu_simulation/EngineModule/engine_data.txt";
     std::ifstream infile(dtc_file_path);
 
     if (!infile.is_open())
@@ -181,7 +182,7 @@ void EngineModule::checkDTC()
         infile.close();
     }
     /* Read the map with DIDs from the file */
-    std::unordered_map<uint16_t, std::vector<uint8_t>> current_DID_value = FileManager::readMapFromFile("engine_data.txt");
+    std::unordered_map<uint16_t, std::vector<uint8_t>> current_DID_value = FileManager::readMapFromFile(engine_file_path);
 
     /* Fuel Pressure DTC*/
     FileManager::writeDTC(current_DID_value, dtc_file_path, 0x012C, 30, 50, "P0190 24");

--- a/src/uds/write_data_by_identifier/utest/WriteDataByIdentifierTest.cpp
+++ b/src/uds/write_data_by_identifier/utest/WriteDataByIdentifierTest.cpp
@@ -1,46 +1,123 @@
-#include <iostream>
-#include <vector>
-#include <cstdint>
+#include <cstring>
 #include <string>
+#include <thread>
+#include <fcntl.h>
+#include <sys/ioctl.h>
 #include <gtest/gtest.h>
-#include <linux/can.h>
+#include <net/if.h>
+
 #include "../include/WriteDataByIdentifier.h"
-#include "../../../utils/include/Logger.h"
-#include "../../../ecu_simulation/BatteryModule/include/BatteryModule.h"
-#include "../../../mcu/include/MCUModule.h"
+#include "../../../utils/include/ReceiveFrames.h"
 
-/* Test Fixture for WriteDataByIdentifier */
-class WriteDataByIdentifierTest : public ::testing::Test {
-protected:
-    canid_t frame_id;
-    std::vector<uint8_t> frame_data;
-    Logger* mockLogger;
-    WriteDataByIdentifier* writeDataByIdentifier;
+int socket1;
+int socket2;
+const int id = 0x10FA;
 
+std::vector<uint8_t> seed;
+
+class CaptureFrame
+{
+    public:
+        struct can_frame frame;
+        void capture()
+        {
+            read(socket1, &frame, sizeof(struct can_frame));
+        }
+};
+
+struct can_frame createFrame(uint16_t can_id ,std::vector<uint8_t> test_data)
+{
+    struct can_frame result_frame;
+    result_frame.can_id = can_id;
+    int i=0;
+    for (auto d : test_data)
+    {
+        result_frame.data[i++] = d;
+    }
+    result_frame.can_dlc = test_data.size();
+    return result_frame;
+}
+
+int createSocket()
+{
+    /* Create socket */
+    std::string name_interface = "vcan1";
+    struct sockaddr_can addr;
+    struct ifreq ifr;
+    int s;
+
+    s = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+    if (s < 0)
+    {
+        std::cout<<"Error trying to create the socket\n";
+        return 1;
+    }
+    /* Giving name and index to the interface created */
+    strcpy(ifr.ifr_name, name_interface.c_str() );
+    ioctl(s, SIOCGIFINDEX, &ifr);
+    /* Set addr structure with info. of the CAN interface */
+    addr.can_family = AF_CAN;
+    addr.can_ifindex = ifr.ifr_ifindex;
+    /* Bind the socket to the CAN interface */
+    int b = bind(s, (struct sockaddr*)&addr, sizeof(addr));
+    if( b < 0 )
+    {
+        std::cout<<"Error binding\n";
+        return 1;
+    }
+    int flags = fcntl(s, F_GETFL, 0);
+    if (flags == -1)
+    {
+        return 1;
+    }
+    /* Set the O_NONBLOCK flag to make the socket non-blocking */
+    flags |= O_NONBLOCK;
+    if (fcntl(s, F_SETFL, flags) == -1)
+    {
+        return -1;
+    }
+    return s;
+}
+
+void testFrames(struct can_frame expected_frame, CaptureFrame &c1 )
+{
+    EXPECT_EQ(expected_frame.can_id & 0xFFFF, c1.frame.can_id & 0xFFFF);
+    EXPECT_EQ(expected_frame.can_dlc, c1.frame.can_dlc);
+    for (int i = 0; i < expected_frame.can_dlc; ++i)
+    {
+        EXPECT_EQ(expected_frame.data[i], c1.frame.data[i]);
+    }
+}
+
+bool containsLine(const std::string& output, const std::string& line)
+{
+    return output.find(line) != std::string::npos;
+}
+
+uint8_t computeKey(uint8_t& seed)
+{
+    return ~seed + 1;
+}
+
+struct WriteDataByIdentifierTest : testing::Test
+{
+    WriteDataByIdentifier* w;
+    SecurityAccess* r;
+    CaptureFrame* c1;
+    Logger* logger;
     WriteDataByIdentifierTest()
-    {   
-        mockLogger = new Logger;
-        battery = new BatteryModule(0x00, 0x11);
-        MCU::mcu = new MCU::MCUModule(0x01);
-        writeDataByIdentifier = new WriteDataByIdentifier(frame_id, frame_data, *mockLogger, 1);
+    {
+        logger = new Logger();
+        w = new WriteDataByIdentifier(*logger, socket2);
+        r = new SecurityAccess(socket2, *logger);
+        c1 = new CaptureFrame();
     }
-    WriteDataByIdentifierTest()
-    {  
-        delete mockLogger;
-        delete writeDataByIdentifier;
-        MCU::mcu = nullptr;
-        battery = nullptr;
-    }
-
-    void SetUp() override {
-        /* Example frame ID */
-        frame_id = 0x10FA;
-        /* Example frame data */
-        frame_data = {0x2E, 0x00, 0x01, 0x02, 0x03};
-    }
-
-    void TearDown() override {
-        delete writeDataByIdentifier;
+    ~WriteDataByIdentifierTest()
+    {
+        delete w;
+        delete r;
+        delete c1;
+        delete logger;
     }
 };
 
@@ -48,110 +125,203 @@ protected:
 TEST_F(WriteDataByIdentifierTest, IncorrectMessageLength) {
     std::cerr << "Running TestIncorrectMessageLength" << std::endl;
     
-    std::vector<uint8_t> invalid_frame_data = {0x2E, 0x00};
+    struct can_frame result_frame = createFrame(0x10FA, {0x03, 0x7F, 0x2e, NegativeResponse::IMLOIF});
 
-    testing::internal::CaptureStdout();
-    WriteDataByIdentifier writeDataByIdentifier(frame_id, invalid_frame_data, *mockLogger, 1);
-
-    std::string output = testing::internal::GetCapturedStdout();
-    EXPECT_NE(output.find("Write Data By Identifier Service invoked."), std::string::npos);
-    EXPECT_NE(output.find("Incorrect Message Length or Invalid Format"), std::string::npos);
+    w->WriteDataByIdentifierService(0xFA10, {0x01, 0x2e});
+    c1->capture();
+    testFrames(result_frame, *c1);
     std::cerr << "Finished TestIncorrectMessageLength" << std::endl;
 }
 
-/* Test for Valid Data Identifier in MCUModule on API socket*/
-TEST_F(WriteDataByIdentifierTest, ValidDIDInMCUModuleOnAPISocket) {
-    std::cerr << "Running TestValidDIDInMCUModuleOnAPISocket" << std::endl;
-    MCU::mcu->mcu_data[0xfa90] = {0x01};
-    frame_id = 0xFA10;
-    frame_data = {0x05, 0x2E, 0xf1, 0x90, 0x12, 0x34};
-
-    testing::internal::CaptureStdout();
-    WriteDataByIdentifier writeDataByIdentifier(frame_id, frame_data, *mockLogger, 1);
-
-    std::string output = testing::internal::GetCapturedStdout();
-    EXPECT_NE(output.find("Write Data By Identifier Service invoked."), std::string::npos);
-    EXPECT_NE(output.find("Data written to new DID 0xf190 in MCUModule."), std::string::npos);
-    EXPECT_NE(output.find("MCUModule contents:"), std::string::npos);
-    EXPECT_NE(output.find("DID 0xf190: 12 34"), std::string::npos);
-    std::cerr << "Finished TestValidDIDInMCUModuleOnAPISocket" << std::endl;
-}
-
-/* Test for Valid Data Identifier in MCUModule on CANBus socket*/
-TEST_F(WriteDataByIdentifierTest, ValidDIDInMCUModuleOnCANBusSocket) {
-    std::cerr << "Running TestValidDIDInMCUModuleOnCANBusSocket" << std::endl;
-    MCU::mcu->mcu_data[0xf260] = {0x01};
-    frame_id = 0x1110;
-    frame_data = {0x05, 0x2E, 0xf2, 0x60, 0x12, 0x34};
-
-    testing::internal::CaptureStdout();
-    WriteDataByIdentifier writeDataByIdentifier(frame_id, frame_data, *mockLogger, 1);
-
-    std::string output = testing::internal::GetCapturedStdout();
-    EXPECT_NE(output.find("Write Data By Identifier Service invoked."), std::string::npos);
-    EXPECT_NE(output.find("Data written to DID 0xf260 in MCUModule."), std::string::npos);
-    EXPECT_NE(output.find("MCUModule contents:"), std::string::npos);
-    std::cerr << "Finished TestValidDIDInMCUModuleOnCANBusSocket" << std::endl;
-}
-
-/* Test for Valid Data Identifier in BatteryModule */
-TEST_F(WriteDataByIdentifierTest, ValidDIDInBatteryModule) {
-    std::cerr << "Running TestValidDIDInBatteryModule" << std::endl;
-
-    frame_id = 0xFA11;
-    frame_data = {0x05, 0x2E, 0x01, 0xd0, 0x12, 0x34};
-
-    testing::internal::CaptureStdout();
-    WriteDataByIdentifier writeDataByIdentifier(frame_id, frame_data, *mockLogger, 1);
-
-    std::string output = testing::internal::GetCapturedStdout();
-    EXPECT_NE(output.find("Write Data By Identifier Service invoked."), std::string::npos);
-    EXPECT_NE(output.find("Data written to DID 0x1d0 in BatteryModule."), std::string::npos);
-    EXPECT_NE(output.find("BatteryModule contents:"), std::string::npos);
-    EXPECT_NE(output.find("DID 0x01d0: 12 34"), std::string::npos);
-    EXPECT_NE(output.find("DID 0x01c0: 00"), std::string::npos);
-    EXPECT_NE(output.find("DID 0x01b0: 00"), std::string::npos);
-    EXPECT_NE(output.find("DID 0x01a0: 00"), std::string::npos);
-    std::cerr << "Finished TestValidDIDInBatteryModule" << std::endl;
-}
-
-/* Test for New Valid Data Identifier in BatteryModule */
-TEST_F(WriteDataByIdentifierTest, NewValidDIDInBatteryModule) {
-    std::cerr << "Running TestNewValidDIDInBatteryModule" << std::endl;
-
-    frame_id = 0xFA11;
-    frame_data = {0x05, 0x2E, 0xf1, 0x8c, 0x03, 0x04};
-
-    testing::internal::CaptureStdout();
-    WriteDataByIdentifier writeDataByIdentifier(frame_id, frame_data, *mockLogger, 1);
-
-    std::string output = testing::internal::GetCapturedStdout();
-    EXPECT_NE(output.find("Write Data By Identifier Service invoked."), std::string::npos);
-    EXPECT_NE(output.find("Data written to new DID 0xf18c in BatteryModule."), std::string::npos);
-    EXPECT_NE(output.find("BatteryModule contents:"), std::string::npos);
-    EXPECT_NE(output.find("DID 0x01c0: 00"), std::string::npos);
-    EXPECT_NE(output.find("DID 0x01b0: 00"), std::string::npos);
-    EXPECT_NE(output.find("DID 0xf18c: 03 04"), std::string::npos);
-    std::cerr << "Finished TestNewValidDIDInBatteryModule" << std::endl;
-}
-
-/* Test for Invalid Data Identifier */
-TEST_F(WriteDataByIdentifierTest, InvalidDID) {
-    std::cerr << "Running TestInvalidDID" << std::endl;
+/* Test for MCU security */
+TEST_F(WriteDataByIdentifierTest, MCUSecurity) {
+    std::cerr << "Running MCUSecurity" << std::endl;
     
-    frame_id = 0xFA10;
-    std::vector<uint8_t> invalid_did_frame = {0x05, 0x2E, 0xff, 0xff, 0x03, 0x04};
+    struct can_frame result_frame = createFrame(0x10FA, {0x03, 0x7F, 0x2e, NegativeResponse::SAD});
 
-    testing::internal::CaptureStdout();
-    WriteDataByIdentifier writeDataByIdentifier(frame_id, invalid_did_frame, *mockLogger, 1);
-
-    std::string output = testing::internal::GetCapturedStdout();
-    EXPECT_NE(output.find("Write Data By Identifier Service invoked."), std::string::npos);
-    EXPECT_NE(output.find("Request Out Of Range: Identifier not found in memory"), std::string::npos);
-    std::cerr << "Finished TestInvalidDID" << std::endl;
+    w->WriteDataByIdentifierService(0xFA10, {0x04, 0x2e, 0xf1, 0x90, 0x11});
+    c1->capture();
+    testFrames(result_frame, *c1);
+    std::cerr << "Finished MCUSecurity" << std::endl;
 }
 
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+/* Test for ECUs security */
+TEST_F(WriteDataByIdentifierTest, ECUsSecurity) {
+    std::cerr << "Running ECUsSecurity" << std::endl;
+    
+    struct can_frame result_frame = createFrame(0x11FA, {0x03, 0x7F, 0x2e, NegativeResponse::SAD});
+
+    w->WriteDataByIdentifierService(0xFA11, {0x04, 0x2e, 0xf1, 0x90, 0x11});
+    c1->capture();
+    testFrames(result_frame, *c1);
+    std::cerr << "Finished ECUsSecurity" << std::endl;
+}
+
+/* Test Request Out Of Range MCU */
+TEST_F(WriteDataByIdentifierTest, RequestOutOfRangeMCU) {
+    std::cerr << "Running RequestOutOfRangeMCU" << std::endl;
+
+    struct can_frame result_frame = createFrame(0x10FA, {0x03, 0x7F, 0x2e, NegativeResponse::ROOR});
+
+    /* Check the security */
+    /* Request seed */
+    r->securityAccess(0xFA10, {0x02, 0x27, 0x01});
+
+    c1->capture();
+    if (c1->frame.can_dlc >= 4)
+    {
+        seed.clear();
+        /* from 3 to pci_length we have the seed generated in response */
+        for (int i = 3; i <= c1->frame.data[0]; i++)
+        {
+            seed.push_back(c1->frame.data[i]);
+        }
+    }
+    /* Compute key from seed */
+    for (auto &elem : seed)
+    {
+        elem = computeKey(elem);
+    }
+    std::vector<uint8_t> data_frame = {static_cast<uint8_t>(seed.size() + 2), 0x27, 0x02};
+    data_frame.insert(data_frame.end(), seed.begin(), seed.end());
+    r->securityAccess(0xFA10, data_frame);
+    c1->capture();
+
+    w->WriteDataByIdentifierService(0xFA10, {0x04, 0x2e, 0x11, 0x11, 0x11});
+    c1->capture();
+    testFrames(result_frame, *c1);
+    std::cerr << "Finished RequestOutOfRangeMCU" << std::endl;
+}
+
+/* Test Request Out Of Range Battery */
+TEST_F(WriteDataByIdentifierTest, RequestOutOfRangeBattery) {
+    std::cerr << "Running RequestOutOfRangeBattery" << std::endl;
+    ReceiveFrames* receiveFrames = new ReceiveFrames(socket2, 0x11, *logger);
+    receiveFrames->setEcuState(true);
+    struct can_frame result_frame = createFrame(0x11FA, {0x03, 0x7F, 0x2e, NegativeResponse::ROOR});
+    w->WriteDataByIdentifierService(0xFA11, {0x04, 0x2e, 0x11, 0x11, 0x11});
+    c1->capture();
+    testFrames(result_frame, *c1);
+    std::cerr << "Finished RequestOutOfRangeBattery" << std::endl;
+}
+
+/* Test Request Out Of Range Engine */
+TEST_F(WriteDataByIdentifierTest, RequestOutOfRangeEngine) {
+    std::cerr << "Running RequestOutOfRangeEngine" << std::endl;
+
+    struct can_frame result_frame = createFrame(0x12FA, {0x03, 0x7F, 0x2e, NegativeResponse::ROOR});
+
+    w->WriteDataByIdentifierService(0xFA12, {0x04, 0x2e, 0x11, 0x11, 0x11});
+    c1->capture();
+    testFrames(result_frame, *c1);
+    std::cerr << "Finished RequestOutOfRangeEngine" << std::endl;
+}
+
+/* Test Request Out Of Range Doors */
+TEST_F(WriteDataByIdentifierTest, RequestOutOfRangeDoors) {
+    std::cerr << "Running RequestOutOfRangeDoors" << std::endl;
+
+    struct can_frame result_frame = createFrame(0x13FA, {0x03, 0x7F, 0x2e, NegativeResponse::ROOR});
+
+    w->WriteDataByIdentifierService(0xFA13, {0x04, 0x2e, 0x11, 0x11, 0x11});
+    c1->capture();
+    testFrames(result_frame, *c1);
+    std::cerr << "Finished RequestOutOfRangeDoors" << std::endl;
+}
+
+/* Test Request Out Of Range HVAC */
+TEST_F(WriteDataByIdentifierTest, RequestOutOfRangeHVAC) {
+    std::cerr << "Running RequestOutOfRangeHVAC" << std::endl;
+
+    struct can_frame result_frame = createFrame(0x14FA, {0x03, 0x7F, 0x2e, NegativeResponse::ROOR});
+
+    w->WriteDataByIdentifierService(0xFA14, {0x04, 0x2e, 0x11, 0x11, 0x11});
+    c1->capture();
+    testFrames(result_frame, *c1);
+    std::cerr << "Finished RequestOutOfRangeHVAC" << std::endl;
+}
+
+/* Test Corect DID MCU */
+TEST_F(WriteDataByIdentifierTest, CorectDIDMCU) {
+    std::cerr << "Running CorectDIDMCU" << std::endl;
+    struct can_frame result_frame = createFrame(0x10FA, {0x03, 0x6e, 0xf1, 0x90});
+    w->WriteDataByIdentifierService(0xFA10, {0x04, 0x2e, 0xf1, 0x90, 0x11});
+    c1->capture();
+    testFrames(result_frame, *c1);
+    std::cerr << "Finished CorectDIDMCU" << std::endl;
+}
+
+/* Test Corect DID Battery */
+TEST_F(WriteDataByIdentifierTest, CorectDIDBattery) {
+    std::cerr << "Running CorectDIDBattery" << std::endl;
+    struct can_frame result_frame = createFrame(0x11FA, {0x03, 0x6e, 0x01, 0xa0});
+    w->WriteDataByIdentifierService(0xFA11, {0x04, 0x2e, 0x01, 0xa0, 0x11});
+    c1->capture();
+    testFrames(result_frame, *c1);
+    std::cerr << "Finished CorectDIDBattery" << std::endl;
+}
+
+/* Test Corect DID Engine */
+TEST_F(WriteDataByIdentifierTest, CorectDIDEngine) {
+    std::cerr << "Running CorectDIDEngine" << std::endl;
+
+    struct can_frame result_frame = createFrame(0x12FA, {0x03, 0x6e, 0x01, 0x24});
+
+    w->WriteDataByIdentifierService(0xFA12, {0x04, 0x2e, 0x01, 0x24, 0x11});
+    c1->capture();
+    testFrames(result_frame, *c1);
+    std::cerr << "Finished CorectDIDEngine" << std::endl;
+}
+
+/* Test Corect DID Doors */
+TEST_F(WriteDataByIdentifierTest, CorectDIDDoors) {
+    std::cerr << "Running CorectDIDDoors" << std::endl;
+
+    struct can_frame result_frame = createFrame(0x13FA, {0x03, 0x6e, 0x03, 0xa0});
+
+    w->WriteDataByIdentifierService(0xFA13, {0x04, 0x2e, 0x03, 0xa0, 0x11});
+    c1->capture();
+    testFrames(result_frame, *c1);
+    std::cerr << "Finished CorectDIDDoors" << std::endl;
+}
+
+/* Test Corect DID HVAC */
+TEST_F(WriteDataByIdentifierTest, CorectDIDHVAC) {
+    std::cerr << "Running CorectDIDHVAC" << std::endl;
+
+    struct can_frame result_frame = createFrame(0x14FA, {0x03, 0x6e, 0x01, 0x34});
+
+    w->WriteDataByIdentifierService(0xFA14, {0x04, 0x2e, 0x01, 0x34, 0x11});
+    c1->capture();
+    testFrames(result_frame, *c1);
+    std::cerr << "Finished CorectDIDHVAC" << std::endl;
+}
+
+/* Test Module not supported */
+TEST_F(WriteDataByIdentifierTest, ModuleNotSupported) {
+    std::cerr << "Running ModuleNotSupported" << std::endl;
+
+    struct can_frame result_frame = createFrame(0x15FA, {0x03, 0x7F, 0x2e, NegativeResponse::ROOR});
+
+    w->WriteDataByIdentifierService(0xFA15, {0x04, 0x2e, 0x11, 0x11, 0x11});
+    c1->capture();
+    testFrames(result_frame, *c1);
+    std::cerr << "Finished ModuleNotSupported" << std::endl;
+}
+
+int main(int argc, char* argv[])
+{
+    socket1 = createSocket();
+    socket2 = createSocket();
+    testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+    if (socket1 > 0)
+    {
+        close(socket1);
+    }
+    if (socket2 > 0)
+    {
+        close(socket2);
+    }
+    return result;
 }

--- a/src/utils/include/ReceiveFrames.h
+++ b/src/utils/include/ReceiveFrames.h
@@ -179,6 +179,12 @@ public:
      * @return true if the ecu security is enabled, false otherwise.
      */
     static bool getEcuState();
+
+    /**
+     * @brief Set the state of the ecu security system.
+     * 
+     */
+    static void setEcuState(bool value);
     /**
      * @brief Starts the receive process by creating bufferFrameIn and bufferFrameOut threads.
      * 

--- a/src/utils/src/ReceiveFrames.cpp
+++ b/src/utils/src/ReceiveFrames.cpp
@@ -41,6 +41,11 @@ bool ReceiveFrames::getEcuState()
     return ecu_state;
 }
 
+void ReceiveFrames::setEcuState(bool value)
+{
+    ecu_state = value;
+}
+
 void ReceiveFrames::receive(HandleFrames &handle_frame) 
 {
     try 


### PR DESCRIPTION
- Unit tests for the WDBI service fixed (100% coverage)
- Added setter for ecu_state in the utils/ReceiveFrames class to bypass security
- Added absolute paths for ecu*_data.txt and dtcs.txt files to make the tests work

## Trello link [here](https://trello.com/c/Oa7B0dmr/49-rework-tests-for-write-data-by-identifier)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
