### PR TITLE
Decorator to Handle Manual/Automatic Flow & Flask-Limiter

### DIFF
--- a/src/rest_api/actions/base_actions.py
+++ b/src/rest_api/actions/base_actions.py
@@ -92,36 +92,53 @@ class Action(GF):
         """
         flag = False
         msg_ext = None
-        msg = self.bus.recv(35)
+        msg = self.bus.recv(Config.BUS_RECEIVE_TIMEOUT)
         self.last_msg = msg
-        while msg is not None:
 
+        log_info_message(logger, f"[Collect Response] Initial message received: {msg}")
+
+        while msg is not None:
             if msg.data[1] == 0x7F and msg.data[3] == 0x78:
-                log_info_message(logger, f"Response pending for SID {msg.data[2]:02X}. Waiting for the actual response...")
+                log_info_message(logger, f"[Collect Response] Response pending for SID {msg.data[2]:02X}. Waiting for actual response...")
                 msg = self.bus.recv(Config.BUS_RECEIVE_TIMEOUT)
                 self.last_msg = msg
                 continue
+
             # First Frame
             if msg.data[0] == 0x10:
                 flag = True
                 msg_ext = msg[1:]
+                log_info_message(logger, f"[Collect Response] First frame received: {msg_ext}")
+
             # Consecutive frame
             elif flag and 0x20 < msg.data[0] < 0x30:
                 msg_ext.data += msg.data[1:]
-            # Simple Frame
+                log_info_message(logger, f"[Collect Response] Consecutive frame received. Updated data: {msg_ext}")
+
+            # Simple frame or other types
             else:
+                log_info_message(logger, f"[Collect Response] Simple frame or other frame received: {msg}")
                 break
+
             msg = self.bus.recv(Config.BUS_RECEIVE_TIMEOUT)
             self.last_msg = msg
+
+        log_info_message(logger, f"[Collect Response] Final message after processing: {msg}")
+
         if flag:
             msg = msg_ext
+
         if msg is not None and self.__verify_frame(msg, sid):
+            log_info_message(logger, f"[Collect Response] Valid message collected for SID {sid:02X}: {msg}")
+            self.response_collected = True
             return msg
+
+        log_error_message(logger, f"[Collect Response] Invalid or no message collected for SID {sid:02X}")
         return None
 
     def __verify_frame(self, msg: can.Message, sid: int):
 
-        log_info_message(logger, f"Verifying frame with SID: {sid:02X}, message data: {[hex(byte) for byte in msg.data]}")
+        log_info_message(logger, f"[Verify Frame] Verifying frame with SID: {sid:02X}, message data: {[hex(byte) for byte in msg.data]}")
 
         if msg.arbitration_id % 0x100 != self.my_id:
             return False
@@ -152,11 +169,11 @@ class Action(GF):
         Raises:
         - CustomError: If the response is invalid.
         """
-        log_info_message(logger, "Collecting the response")
+        log_info_message(logger, "[Passive Reponse] Collecting the response")
         response = self.__collect_response(sid)
 
         if response:
-            log_info_message(logger, f"Collected response: {response}")
+            log_info_message(logger, f"[Passive Reponse] Collected response: {response}")
         else:
             log_error_message(logger, error_str)
 
@@ -196,11 +213,11 @@ class Action(GF):
         Returns:
         - Data as a string.
         """
-        log_info_message(logger, f"Read from identifier {identifier}")
+        log_info_message(logger, f"[Read by Identifier] Read from identifier {identifier}")
         self.read_data_by_identifier(id, identifier)
         frame_response = self._passive_response(READ_BY_IDENTIFIER,
-                                                f"Error reading data from identifier {identifier}")
-        log_info_message(logger, f"Frame response: {frame_response}")
+                                                f"[Read by Identifier] Error reading data from identifier {identifier}")
+        log_info_message(logger, f"[Read by Identifier] Frame response: {frame_response}")
         data = self._data_from_frame(frame_response)
         data_str = self._list_to_number(data)
         return data_str
@@ -217,7 +234,7 @@ class Action(GF):
         Returns:
         - True if the operation is triggered.
         """
-        log_info_message(logger, f"Write by identifier {identifier}")
+        log_info_message(logger, f"[Write by Identifier] Write by identifier {identifier}")
 
         value_list = self._number_to_list(value)
 
@@ -226,7 +243,7 @@ class Action(GF):
         else:
             self.write_data_by_identifier(id, identifier, value_list)
 
-        self._passive_response(WRITE_BY_IDENTIFIER, f"Operation complete for identifier {identifier}")
+        self._passive_response(WRITE_BY_IDENTIFIER, f"[Write by Identifier] Operation complete for identifier {identifier}")
 
         return True
 

--- a/src/rest_api/actions/base_actions.py
+++ b/src/rest_api/actions/base_actions.py
@@ -155,6 +155,11 @@ class Action(GF):
         log_info_message(logger, "Collecting the response")
         response = self.__collect_response(sid)
 
+        if response:
+            log_info_message(logger, f"Collected response: {response}")
+        else:
+            log_error_message(logger, error_str)
+
         if response is None:
             log_error_message(logger, error_str)
             response_json = self._to_json_error("interrupted", 1)

--- a/src/rest_api/actions/read_info_action.py
+++ b/src/rest_api/actions/read_info_action.py
@@ -316,10 +316,7 @@ class ReadInfo(Action):
         - JSON response with HVAC data or the data for a specific item if provided.
 
         Endpoint test (external flow):
-
         curl -X GET "http://127.0.0.1:5000/api/read_info_hvac?is_manual_flow=false" -H "Content-Type: application/json"
-
-        
         """
         try:
             log_info_message(logger, "Reading data from HVAC")

--- a/src/rest_api/actions/read_info_action.py
+++ b/src/rest_api/actions/read_info_action.py
@@ -94,8 +94,6 @@ class ReadInfo(Action):
                 if item in identifiers:
                     identifier = identifiers[item]
                     result_value = self._read_by_identifier(id, int(identifier, 16))
-                    if not result_value:
-                        self._passive_response(READ_BY_IDENTIFIER, f"Error reading {identifier}")
 
                     if item == "state_of_charge" and result_value:
                         result_value = self._get_battery_state_of_charge(result_value)
@@ -113,8 +111,6 @@ class ReadInfo(Action):
             else:
                 for key, identifier in identifiers.items():
                     result_value = self._read_by_identifier(id, int(identifier, 16))
-                    if not result_value:
-                        self._passive_response(READ_BY_IDENTIFIER, f"Error reading {identifier}")
 
                     if key == "state_of_charge" and result_value:
                         result_value = self._get_battery_state_of_charge(result_value)
@@ -187,8 +183,6 @@ class ReadInfo(Action):
                 if item in identifiers:
                     identifier = identifiers[item]
                     result_value = self._read_by_identifier(id, int(identifier, 16))
-                    if not result_value:
-                        self._passive_response(READ_BY_IDENTIFIER, f"Error reading {identifier}")
                     context = get_context(item)
 
                     results[item] = self._interpret_status(result_value, context) if result_value else "No data"
@@ -204,8 +198,6 @@ class ReadInfo(Action):
             else:
                 for key, identifier in identifiers.items():
                     result_value = self._read_by_identifier(id, int(identifier, 16))
-                    if not result_value:
-                        self._passive_response(READ_BY_IDENTIFIER, f"Error reading {identifier}")
                     context = get_context(key)
 
                     results[key] = self._interpret_status(result_value, context) if result_value else "No data"
@@ -263,8 +255,6 @@ class ReadInfo(Action):
                 if item in identifiers:
                     identifier = identifiers[item]
                     result_value = self._read_by_identifier(id, int(identifier, 16))
-                    if not result_value:
-                        self._passive_response(READ_BY_IDENTIFIER, f"Error reading {identifier}")
                     interpreted_value = self.hex_to_dec(result_value) if result_value else "No data"
 
                     response_json = {
@@ -281,8 +271,6 @@ class ReadInfo(Action):
                 for key, identifier in identifiers.items():
                     result_value = self._read_by_identifier(id, int(identifier, 16))
                     results[key] = self.hex_to_dec(result_value) if result_value else "No data"
-                    if not result_value:
-                        self._passive_response(READ_BY_IDENTIFIER, f"Error reading {identifier}")
 
                 response_json = {
                     **results,
@@ -329,8 +317,6 @@ class ReadInfo(Action):
                 if item in identifiers:
                     identifier = identifiers[item]
                     result_value = self._read_by_identifier(id, int(identifier, 16))
-                    if not result_value:
-                        self._passive_response(READ_BY_IDENTIFIER, f"Error reading {identifier}")
 
                     if item == "hvac_modes":
                         interpreted_value = self._interpret_hvac_modes(self.hex_to_dec(result_value)) if result_value else "No data"
@@ -349,8 +335,6 @@ class ReadInfo(Action):
             else:
                 for key, identifier in identifiers.items():
                     result_value = self._read_by_identifier(id, int(identifier, 16))
-                    if not result_value:
-                        self._passive_response(READ_BY_IDENTIFIER, f"Error reading {identifier}")
 
                     if key == "hvac_modes":
                         results[key] = self._interpret_hvac_modes(self.hex_to_dec(result_value)) if result_value else "No data"

--- a/src/rest_api/actions/read_info_action.py
+++ b/src/rest_api/actions/read_info_action.py
@@ -77,6 +77,11 @@ class ReadInfo(Action):
 
         Returns:
         - JSON response.
+
+        Endpoint test (external flow):
+
+        curl -X GET "http://127.0.0.1:5000/api/read_info_battery?is_manual_flow=false" -H "Content-Type: application/json"
+
         """
         try:
             log_info_message(logger, "Reading data from battery")
@@ -155,6 +160,11 @@ class ReadInfo(Action):
 
         Returns:
         - JSON response.
+
+        Endpoint test (external flow):
+
+        curl -X GET "http://127.0.0.1:5000/api/read_info_doors?is_manual_flow=false" -H "Content-Type: application/json"
+
         """
         try:
             log_info_message(logger, "Reading data from doors")
@@ -235,6 +245,11 @@ class ReadInfo(Action):
 
         Returns:
         - JSON response with engine data or the data for a specific item if provided.
+
+        Endpoint test (external flow):
+
+        curl -X GET "http://127.0.0.1:5000/api/read_info_engine?is_manual_flow=false" -H "Content-Type: application/json"
+
         """
         try:
             log_info_message(logger, "Reading data from engine")
@@ -299,6 +314,12 @@ class ReadInfo(Action):
 
         Returns:
         - JSON response with HVAC data or the data for a specific item if provided.
+
+        Endpoint test (external flow):
+
+        curl -X GET "http://127.0.0.1:5000/api/read_info_hvac?is_manual_flow=false" -H "Content-Type: application/json"
+
+        
         """
         try:
             log_info_message(logger, "Reading data from HVAC")

--- a/src/rest_api/actions/read_info_action.py
+++ b/src/rest_api/actions/read_info_action.py
@@ -96,13 +96,13 @@ class ReadInfo(Action):
                         result_value = self._get_battery_state_of_charge(result_value)
 
                     results[item] = result_value if result_value else "No data"
-                
+
                     response_json = {
                             item: self.hex_to_dec(result_value) if result_value else "No data",
                             "time_stamp": datetime.datetime.now().isoformat()
                         }
                     return response_json
-            
+
                 else:
                     return {"error": f"Invalid parameter '{item}'. Use /get_identifiers to see valid parameters."}
             else:
@@ -223,7 +223,8 @@ class ReadInfo(Action):
                 "message": "Error during Read by ID",
                 "negative_response": negative_response
             }
-
+        except Exception as e:
+            return {"error": f"Unexpected error: {str(e)}"}
 
     def read_from_engine(self, item=None):
         """
@@ -243,7 +244,7 @@ class ReadInfo(Action):
             results = {}
 
             if item:
-            
+
                 if item in identifiers:
                     identifier = identifiers[item]
                     result_value = self._read_by_identifier(id, int(identifier, 16))
@@ -306,7 +307,7 @@ class ReadInfo(Action):
             identifiers = data_identifiers["HVAC_Identifiers"]
             results = {}
             if item:
-            
+
                 if item in identifiers:
                     identifier = identifiers[item]
                     result_value = self._read_by_identifier(id, int(identifier, 16))
@@ -318,7 +319,6 @@ class ReadInfo(Action):
                     else:
                         interpreted_value = self.hex_to_dec(result_value) if result_value else "No data"
 
-                    
                     response_json = {
                         item: interpreted_value,
                         "time_stamp": datetime.datetime.now().isoformat()
@@ -333,13 +333,12 @@ class ReadInfo(Action):
                     result_value = self._read_by_identifier(id, int(identifier, 16))
                     if not result_value:
                         self._passive_response(READ_BY_IDENTIFIER, f"Error reading {identifier}")
-                        
+
                     if key == "hvac_modes":
                         results[key] = self._interpret_hvac_modes(self.hex_to_dec(result_value)) if result_value else "No data"
                     else:
                         results[key] = self.hex_to_dec(result_value) if result_value else "No data"
 
-                    
                 response_json = {
                     **results,
                     "time_stamp": datetime.datetime.now().isoformat()

--- a/src/rest_api/actions/security_decorator.py
+++ b/src/rest_api/actions/security_decorator.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from flask import jsonify
+from flask import jsonify, request
 from actions.secure_auth import Auth
 from actions.diag_session import SessionManager
 from configs.data_identifiers import *
@@ -8,6 +8,17 @@ from configs.data_identifiers import *
 def requires_auth(func):
     @wraps(func)
     def decorated_function(*args, **kwargs):
+
+        if request.method == 'POST':
+            is_manual_flow = request.get_json().get('is_manual_flow', None)
+        elif request.method == 'GET':
+            is_manual_flow = request.args.get('is_manual_flow', None)
+
+        if is_manual_flow is None:
+            return jsonify({"error": "Missing 'is_manual_flow' flag."}), 400
+
+        if is_manual_flow:
+            return func(*args, **kwargs)
         try:
             id = (API_ID << 8) + 0x10
 

--- a/src/rest_api/actions/security_decorator.py
+++ b/src/rest_api/actions/security_decorator.py
@@ -16,6 +16,8 @@ def requires_auth(func):
 
         if is_manual_flow is None:
             return jsonify({"error": "Missing 'is_manual_flow' flag."}), 400
+        
+        is_manual_flow = is_manual_flow.lower() == 'true' if isinstance(is_manual_flow, str) else bool(is_manual_flow)
 
         if is_manual_flow:
             return func(*args, **kwargs)

--- a/src/rest_api/actions/security_decorator.py
+++ b/src/rest_api/actions/security_decorator.py
@@ -16,7 +16,7 @@ def requires_auth(func):
 
         if is_manual_flow is None:
             return jsonify({"error": "Missing 'is_manual_flow' flag."}), 400
-        
+
         is_manual_flow = is_manual_flow.lower() == 'true' if isinstance(is_manual_flow, str) else bool(is_manual_flow)
 
         if is_manual_flow:

--- a/src/rest_api/actions/write_info_action.py
+++ b/src/rest_api/actions/write_info_action.py
@@ -27,6 +27,10 @@ class WriteInfo(Action):
 
         Returns:
         - JSON response.
+
+        Endpoint test (external flow):
+
+        curl -X POST http://127.0.0.1:5000/api/write_info_battery -H "Content-Type: application/json" -d '{"is_manual_flow": false, "battery_level": 75, "voltage": 10, "battery_state_of_charge": 2, "percentage": 10}'
         """
 
         try:
@@ -88,6 +92,10 @@ class WriteInfo(Action):
         - data_dict: Dictionary containing the data to write.
         Returns:
         - JSON response.
+
+        Endpoint test (external flow):
+        
+        curl -X POST http://127.0.0.1:5000/api/write_info_doors -H "Content-Type: application/json" -d '{"is_manual_flow": false, "door": 1, "passenger": 0, "passenger_lock": 1, "driver": 1, "ajar": 0}'
         """
 
         try:
@@ -149,6 +157,11 @@ class WriteInfo(Action):
         - data_dict: Dictionary containing the data to write.
         Returns:
         - JSON response.
+
+        Endpoint test (external flow):
+
+        curl -X POST http://127.0.0.1:5000/api/write_info_engine -H "Content-Type: application/json" -d '{"is_manual_flow": false, "engine_rpm": 23, "coolant_temperature": 43,
+        "throttle_position": 8, "vehicle_speed": 33, "engine_load": 32, "fuel_level": 67, "oil_temperature": 90, "fuel_pressure": 33, "intake_air_temperature": 33}'
         """
         try:
             id = self.my_id * 0x100 + self.id_ecu[ECU_ENGINE]
@@ -214,6 +227,11 @@ class WriteInfo(Action):
         - data_dict: Dictionary containing HVAC parameters to write.
         Returns:
         - JSON response.
+
+        Endpoint test (external flow):
+
+        curl -X POST http://127.0.0.1:5000/api/write_info_engine -H "Content-Type: application/json" -d '{"is_manual_flow": false, "mass_air_flow": 21, "ambient_air_temperature": 44,
+        "cabin_temperature": 18, "cabin_temperature_driver_set": 25, "fan_speed": 45, "hvac_modes":0}'
         """
 
         try:

--- a/src/rest_api/actions/write_info_action.py
+++ b/src/rest_api/actions/write_info_action.py
@@ -120,10 +120,10 @@ class WriteInfo(Action):
 
                 data_parameter = [value]
                 if len(data_parameter) <= 4:
-                    self.generate.write_data_by_identifier(id, identifier, data_parameter)
+                    self.write_data_by_identifier(id, identifier, data_parameter)
                     self._passive_response(WRITE_BY_IDENTIFIER, f"Error writing {identifier}")
                 else:
-                    self.generate.write_data_by_identifier_long(id, identifier, data_parameter)
+                    self.write_data_by_identifier_long(id, identifier, data_parameter)
 
             log_info_message(logger, f"Data written successfully to ECU ID: {ECU_DOORS}")
             response_json = self._to_json("success", 0)
@@ -185,10 +185,10 @@ class WriteInfo(Action):
 
                 data_parameter = [value]
                 if len(data_parameter) <= 4:
-                    self.generate.write_data_by_identifier(id, identifier, data_parameter)
+                    self.write_data_by_identifier(id, identifier, data_parameter)
                     self._passive_response(WRITE_BY_IDENTIFIER, f"Error writing {identifier}")
                 else:
-                    self.generate.write_data_by_identifier_long(id, identifier, data_parameter)
+                    self.write_data_by_identifier_long(id, identifier, data_parameter)
 
             log_info_message(logger, f"Data written successfully to ECU ID: {ECU_ENGINE}")
             response_json = self._to_json("success", 0)
@@ -247,10 +247,10 @@ class WriteInfo(Action):
 
                 data_parameter = [value]
                 if len(data_parameter) <= 4:
-                    self.generate.write_data_by_identifier(id, identifier, data_parameter)
+                    self.write_data_by_identifier(id, identifier, data_parameter)
                     self._passive_response(WRITE_BY_IDENTIFIER, f"Error writing {identifier}")
                 else:
-                    self.generate.write_data_by_identifier_long(id, identifier, data_parameter)
+                    self.write_data_by_identifier_long(id, identifier, data_parameter)
 
             log_info_message(logger, f"Data written successfully to ECU ID: {ECU_HVAC}")
             response_json = self._to_json("success", 0)

--- a/src/rest_api/actions/write_info_action.py
+++ b/src/rest_api/actions/write_info_action.py
@@ -94,7 +94,7 @@ class WriteInfo(Action):
         - JSON response.
 
         Endpoint test (external flow):
-        
+
         curl -X POST http://127.0.0.1:5000/api/write_info_doors -H "Content-Type: application/json" -d '{"is_manual_flow": false, "door": 1, "passenger": 0, "passenger_lock": 1, "driver": 1, "ajar": 0}'
         """
 

--- a/src/rest_api/app.py
+++ b/src/rest_api/app.py
@@ -4,8 +4,18 @@ from config import *
 from routes.main import main_bp
 from flask_cors import CORS
 from routes.api import api_bp
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
 
 app = Flask(__name__)
+
+limiter = Limiter(
+    get_remote_address,
+    app=app,
+    default_limits=["1 per 10 seconds"]
+)
+
 app.config.from_object(Config)
 
 

--- a/src/rest_api/config.py
+++ b/src/rest_api/config.py
@@ -1,8 +1,13 @@
 import os
+from flask import request
+from flask_limiter import Limiter
 
 
 # For Swagger Doc
 YAML_FILE_PATH = os.path.abspath('utils/docs/api_doc.yaml')
+
+
+limiter = Limiter(key_func=lambda: request.remote_addr)
 
 
 class Config:

--- a/src/rest_api/requirements.txt
+++ b/src/rest_api/requirements.txt
@@ -6,6 +6,7 @@ exceptiongroup==1.2.2
 flake8==7.1.0
 flasgger==0.9.7b2
 flask==3.0.3
+Flask-Limiter==3.8.0
 Flask-Cors==4.0.1
 importlib-metadata==8.0.0
 importlib-resources==6.4.0

--- a/src/rest_api/routes/api.py
+++ b/src/rest_api/routes/api.py
@@ -18,6 +18,7 @@ from actions.tester_present import Tester  # noqa: E402
 from actions.access_timing_action import *  # noqa: E402
 from actions.ecu_reset import Reset  # noqa: E402
 from actions.security_decorator import *  # noqa: E402
+from config import *  # noqa: E402
 
 api_bp = Blueprint('api', __name__)
 


### PR DESCRIPTION
## Description

- Adds a decorator to differentiate between manual and automatic flow.
- Integrates Flask-Limiter for rate limiting API requests.
- Bugfix read&write single item for ECU's, double call for passive_reponse

## Trello link [here](https://trello.com/c/RV9h77e9/116-update-decorator-to-handle-external-and-external-calls)
## Trello link [here](https://trello.com/c/QL2S4jQ1/120-flask-request-limiter)
## Trello link [here](https://trello.com/c/4LPRgKqI/19-apiminorindividul-read-by-id)
## Trello link [here](https://trello.com/c/5LClMDxF/23-apiminor-double-call-to-passive-reponse)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
