### PR TITLE
UTRoutineControlPartiallyFixed

### DIFF
--- a/src/mcu/Makefile
+++ b/src/mcu/Makefile
@@ -593,8 +593,8 @@ $(UDS_DIR)/tester_present/utest/TesterPresent_test.o: $(UDS_DIR)/tester_present/
 # RoutineControl Unit tests
 routineControlTest: $(OBJ_DIR) $(UDS_DIR)/routine_control/utest/routineControlTest.out
 
-$(UDS_DIR)/routine_control/utest/routineControlTest.out: $(OBJ_DIR) $(OBJS_ROUTINECONTROL_TEST) $(UDS_DIR)/routine_control/utest/RoutineControl_test.o
-	$(CXX) $(CFLAGSTST) -o $(UDS_DIR)/routine_control/utest/routineControlTest.out $(UDS_DIR)/routine_control/utest/RoutineControl_test.o $(OBJS_ROUTINECONTROL_TEST) $(CFLAGSTST2) $(LDFLAGS)
+$(UDS_DIR)/routine_control/utest/routineControlTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UDS_DIR)/routine_control/utest/RoutineControl_test.o
+	$(CXX) $(CFLAGSTST) -o $(UDS_DIR)/routine_control/utest/routineControlTest.out $(UDS_DIR)/routine_control/utest/RoutineControl_test.o $(OBJS_TEST) $(CFLAGSTST2) $(LDFLAGS)
 
 $(UDS_DIR)/routine_control/utest/RoutineControl_test.o: $(UDS_DIR)/routine_control/utest/RoutineControlTest.cpp
 	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UDS_DIR)/routine_control/utest/RoutineControlTest.cpp -o $(UDS_DIR)/routine_control/utest/RoutineControl_test.o $(CFLAGSTST2) $(LDFLAGS)

--- a/src/uds/ecu_reset/include/EcuReset.h
+++ b/src/uds/ecu_reset/include/EcuReset.h
@@ -39,6 +39,12 @@ public:
      * @param logger The logger
      */
     EcuReset(uint32_t can_id, uint8_t sub_function, int socket, Logger &logger);
+
+    /**
+     * @brief Destroy the Ecu Reset object
+     * 
+     */
+    ~EcuReset();
     /**
      * @brief Method that checks the subfunction and calls either hardReset() or keyOffReset().
      * data A vector containing the data bytes to be processed.

--- a/src/uds/ecu_reset/src/EcuReset.cpp
+++ b/src/uds/ecu_reset/src/EcuReset.cpp
@@ -10,6 +10,11 @@ EcuReset::EcuReset(uint32_t can_id, uint8_t sub_function, int socket, Logger &lo
 {
 }
 
+EcuReset::~EcuReset()
+{
+    LOG_INFO(ECUResetLog.GET_LOGGER(), "Ecu Reset object out of scope");
+}
+
 void EcuReset::ecuResetRequest(const std::vector<uint8_t>& request)
 {
     uint8_t lowerbits = can_id & 0xFF;

--- a/src/uds/routine_control/src/RoutineControl.cpp
+++ b/src/uds/routine_control/src/RoutineControl.cpp
@@ -56,6 +56,7 @@ void RoutineControl::routineControl(canid_t can_id, const std::vector<uint8_t>& 
     {
         nrc.sendNRC(can_id,ROUTINE_CONTROL_SID,NegativeResponse::SAD);
         AccessTimingParameter::stopTimingFlag(lowerbits, 0x31);
+        return;
     }
     /* when our identifiers will be defined, this range should be smaller */
     if (routine_identifier < 0x0100 || routine_identifier > 0x0601)

--- a/src/uds/routine_control/utest/RoutineControlTest.cpp
+++ b/src/uds/routine_control/utest/RoutineControlTest.cpp
@@ -1,4 +1,6 @@
 #include "../include/RoutineControl.h"
+#include "../../diagnostic_session_control/include/DiagnosticSessionControl.h"
+#include "../../utils/include/FileManager.h"
 
 #include <cstring>
 #include <string>
@@ -11,8 +13,8 @@
 
 int socket_;
 int socket2_;
-/* Const */
-const int id = 0x3412;
+std::vector<uint8_t> seed;
+std::string file_path = std::string(PROJECT_PATH) + "/src/mcu/mcu_data.txt";
 
 /* Class to capture the frame sin the can-bus */
 class CaptureFrame
@@ -68,6 +70,19 @@ int createSocket()
     return s;
 }
 
+struct can_frame createFrame(uint32_t can_id ,std::vector<uint8_t> test_data)
+{
+    struct can_frame result_frame;
+    result_frame.can_id = can_id;
+    int i=0;
+    for (auto d : test_data)
+    {
+        result_frame.data[i++] = d;
+    }
+    result_frame.can_dlc = test_data.size();
+    return result_frame;
+}
+
 void testFrames(struct can_frame expected_frame, CaptureFrame &c1 )
 {
     EXPECT_EQ(expected_frame.can_id && 0xFFFF, c1.frame.can_id && 0xFFFF);
@@ -76,90 +91,210 @@ void testFrames(struct can_frame expected_frame, CaptureFrame &c1 )
         EXPECT_EQ(expected_frame.data[i], c1.frame.data[i]);
     }
 }
+
+uint8_t computeKey(uint8_t& seed)
+{
+    return ~seed + 1;
+}
+
 /* Create object for all tests */
 struct RoutineControlTest : testing::Test
 {
     RoutineControl* routine_control;
+    SecurityAccess* r;
+    DiagnosticSessionControl* dsc;
     CaptureFrame* capture_frame;
     Logger logger;
     RoutineControlTest()
     {
         routine_control = new RoutineControl(socket2_,logger);
+        r = new SecurityAccess(socket2_, logger);
+        dsc = new DiagnosticSessionControl(logger, socket2_);
         capture_frame = new CaptureFrame();
     }
     ~RoutineControlTest()
     {
         delete routine_control;
+        delete r;
+        delete dsc;
         delete capture_frame;
+    }
+
+    void checkSecurity()
+    {
+        /* Check the security */
+        /* Request seed */
+        r->securityAccess(0xFA10, {0x02, 0x27, 0x01});
+
+        capture_frame->capture();
+        if (capture_frame->frame.can_dlc >= 4)
+        {
+            seed.clear();
+            /* from 3 to pci_length we have the seed generated in response */
+            for (int i = 3; i <= capture_frame->frame.data[0]; i++)
+            {
+                seed.push_back(capture_frame->frame.data[i]);
+            }
+        }
+        /* Compute key from seed */
+        for (auto &elem : seed)
+        {
+            elem = computeKey(elem);
+        }
+
+        std::vector<uint8_t> data_frame = {static_cast<uint8_t>(seed.size() + 2), 0x27, 0x02};
+        data_frame.insert(data_frame.end(), seed.begin(), seed.end());
+        r->securityAccess(0xFA10, data_frame);
+        capture_frame->capture();
     }
 };
 
 TEST_F(RoutineControlTest, IncorrectMessageLength)
 {
-    std::vector<uint8_t> invalid_frame_data = {0x03, 0x31, 0x01, 0x02};
-    std::vector<uint8_t> expected_frame_data = {0x03, 0x7F, 0x31, 0x13};
-    routine_control->routineControl(0x1110, invalid_frame_data);
+     struct can_frame expected_frame = createFrame(0x001010FA, {0x03, 0x7F, 0x31, NegativeResponse::IMLOIF});
+
+    routine_control->routineControl(0x0010fa10, {0x03, 0x31, 0x01, 0x02});
     capture_frame->capture();
-    for (int i = 0; i < capture_frame->frame.can_dlc; ++i) {
-        EXPECT_EQ(expected_frame_data[i], capture_frame->frame.data[i]);
-    }
+    testFrames(expected_frame, *capture_frame);
 }
 
 TEST_F(RoutineControlTest, SubFunctionNotSupported)
 {
-    std::vector<uint8_t> invalid_frame_data = {0x03, 0x31, 0x00, 0x01, 0x03, 0x03};
-    std::vector<uint8_t> expected_frame_data = {0x03, 0x7F, 0x31, 0x12};
-    routine_control->routineControl(0x1110, invalid_frame_data);
+    struct can_frame expected_frame = createFrame(0x001010FA, {0x03, 0x7F, 0x31, 0x12});
+
+    routine_control->routineControl(0x0010fa10, {0x05, 0x31, 0x00, 0x01, 0x03, 0x03});
     capture_frame->capture();
-    for (int i = 0; i < capture_frame->frame.can_dlc; ++i) {
-        EXPECT_EQ(expected_frame_data[i], capture_frame->frame.data[i]);
-    }
+    testFrames(expected_frame, *capture_frame);
+}
+
+TEST_F(RoutineControlTest, MCUSecurity)
+{
+    struct can_frame expected_frame = createFrame(0x001010FA, {0x03, 0x7F, 0x31, NegativeResponse::SAD});
+
+    dsc->sessionControl(0x0010fa10, 0x03);
+    capture_frame->capture();
+    routine_control->routineControl(0x0010FA10, {0x05, 0x31, 0x01, 0x02, 0x01, 0x10});
+    capture_frame->capture();
+    testFrames(expected_frame, *capture_frame);
+}
+
+TEST_F(RoutineControlTest, ECUSecurity)
+{
+    struct can_frame expected_frame = createFrame(0x001011FA, {0x03, 0x7F, 0x31, NegativeResponse::SAD});
+
+    routine_control->routineControl(0x0010FA11, {0x05, 0x31, 0x01, 0x02, 0x01, 0x10});
+    capture_frame->capture();
+    testFrames(expected_frame, *capture_frame);
 }
 
 TEST_F(RoutineControlTest, RequestOutOfRange)
 {
-    std::vector<uint8_t> invalid_frame_data = {0x03, 0x31, 0x01, 0x00, 0x00, 0x03};
-    std::vector<uint8_t> expected_frame_data = {0x03, 0x7F, 0x31, 0x31};
-    routine_control->routineControl(0x1110, invalid_frame_data);
+
+    struct can_frame expected_frame = createFrame(0x001010FA, {0x03, 0x7F, 0x31, NegativeResponse::ROOR});
+
+    checkSecurity();
+
+    routine_control->routineControl(0x0010FA10, {0x05, 0x31, 0x01, 0x00, 0x01, 0x10});
     capture_frame->capture();
-    for (int i = 0; i < capture_frame->frame.can_dlc; ++i) {
-        EXPECT_EQ(expected_frame_data[i], capture_frame->frame.data[i]);
-    }
+    testFrames(expected_frame, *capture_frame);
 }
 
-TEST_F(RoutineControlTest, PositiveResponseCase1)
+TEST_F(RoutineControlTest, EraseMemory)
 {
-    std::vector<uint8_t> invalid_frame_data = {0x03, 0x31, 0x01, 0x01, 0x01, 0x03};
-    std::vector<uint8_t> expected_frame_data = {0x04, 0x71, 0x01, 0x01, 0x01};
-    routine_control->routineControl(0x1110, invalid_frame_data);
+    struct can_frame expected_frame = createFrame(0x001010FA, {0x05, 0x71, 0x01, 0x01, 0x01, 0x00});
+
+    checkSecurity();
+
+    routine_control->routineControl(0x0010FA10, {0x05, 0x31, 0x01, 0x01, 0x01, 0x00});
     capture_frame->capture();
-    for (int i = 0; i < capture_frame->frame.can_dlc; ++i) {
-        EXPECT_EQ(expected_frame_data[i], capture_frame->frame.data[i]);
-    }
+    testFrames(expected_frame, *capture_frame);
 }
 
-TEST_F(RoutineControlTest, PositiveResponseCase2)
+TEST_F(RoutineControlTest, WrongSession)
 {
-    std::vector<uint8_t> invalid_frame_data = {0x03, 0x31, 0x01, 0x02, 0x01, 0x03};
-    std::vector<uint8_t> expected_frame_data = {0x04, 0x71, 0x01, 0x02, 0x01};
-    routine_control->routineControl(0x1110, invalid_frame_data);
+    dsc->sessionControl(0x0010fa10, 0x02);
     capture_frame->capture();
-    for (int i = 0; i < capture_frame->frame.can_dlc; ++i) {
-        EXPECT_EQ(expected_frame_data[i], capture_frame->frame.data[i]);
-    }
+
+    struct can_frame expected_frame = createFrame(0x001010FA, {0x03, 0x7F, 0x31, NegativeResponse::SFNSIAS});
+    checkSecurity();
+
+    routine_control->routineControl(0x0010FA10, {0x05, 0x31, 0x01, 0x02, 0x01, 0x00});
+    capture_frame->capture();
+    testFrames(expected_frame, *capture_frame);
 }
 
-TEST_F(RoutineControlTest, PositiveResponseDefaultCase)
+TEST_F(RoutineControlTest, OTAStateAlreadyInitialised)
 {
-    std::vector<uint8_t> invalid_frame_data = {0x03, 0x31, 0x01, 0x03, 0x01, 0x03};
-    std::vector<uint8_t> expected_frame_data = {0x04, 0x71, 0x01, 0x03, 0x01};
-    routine_control->routineControl(0x1110, invalid_frame_data);
+    dsc->sessionControl(0x0010fa10, 0x03);
     capture_frame->capture();
-    for (int i = 0; i < capture_frame->frame.can_dlc; ++i) {
-        EXPECT_EQ(expected_frame_data[i], capture_frame->frame.data[i]);
-    }
+    
+    struct can_frame expected_frame = createFrame(0x001010FA, {0x03, 0x7F, 0x31, NegativeResponse::CNC});
+    checkSecurity();
+
+    std::unordered_map<uint16_t, std::vector<uint8_t>> data_map = {{0x01E0, {0x40}}};
+    FileManager::writeMapToFile(file_path, data_map);
+
+    routine_control->routineControl(0x0010FA10, {0x05, 0x31, 0x01, 0x02, 0x01, 0x00});
+    capture_frame->capture();
+    testFrames(expected_frame, *capture_frame);
 }
 
+TEST_F(RoutineControlTest, VersionNotFound )
+{
+    std::unordered_map<uint16_t, std::vector<uint8_t>> data_map = {{0x01E0, {0xff}}};
+    FileManager::writeMapToFile(file_path, data_map);
+    struct can_frame expected_frame = createFrame(0x001010FA, {0x03, 0x7F, 0x31, NegativeResponse::IMLOIF});
+    checkSecurity();
+
+    routine_control->routineControl(0x0010FA10, {0x05, 0x31, 0x01, 0x02, 0x01, 0x70});
+    capture_frame->capture();
+    testFrames(expected_frame, *capture_frame);
+}
+
+TEST_F(RoutineControlTest, InvalidEcuPath)
+{
+    struct can_frame expected_frame = createFrame(0x001015FA, {0x03, 0x7F, 0x31, NegativeResponse::SFNSIAS});
+    checkSecurity();
+
+    routine_control->routineControl(0x0010FA15, {0x05, 0x31, 0x01, 0x03, 0x01, 0x10});
+    capture_frame->capture();
+    testFrames(expected_frame, *capture_frame);
+}
+
+TEST_F(RoutineControlTest, PositiveResponse1)
+{
+    struct can_frame expected_frame = createFrame(0x001010FA, {0x05, 0x71, 0x01, 0x04, 0x01, 0x00});
+    checkSecurity();
+
+    routine_control->routineControl(0x0010FA10, {0x05, 0x31, 0x01, 0x04, 0x01, 0x10});
+    capture_frame->capture();
+    testFrames(expected_frame, *capture_frame);
+}
+
+TEST_F(RoutineControlTest, OTARollbackWrongSession)
+{ 
+    struct can_frame expected_frame = createFrame(0x001010FA, {0x03, 0x7F, 0x31, NegativeResponse::CNC});
+    checkSecurity();
+
+    routine_control->routineControl(0x0010FA10, {0x05, 0x31, 0x01, 0x05, 0x01, 0x00});
+    capture_frame->capture();
+    testFrames(expected_frame, *capture_frame);
+}
+
+TEST_F(RoutineControlTest, SaveCurrentSoftwareFailed)
+{ 
+    struct can_frame expected_frame = createFrame(0x001010FA, {0x03, 0x7F, 0x31, NegativeResponse::IMLOIF});
+    checkSecurity();
+
+    routine_control->routineControl(0x0010FA10, {0x05, 0x31, 0x01, 0x06, 0x01, 0x00});
+    capture_frame->capture();
+    testFrames(expected_frame, *capture_frame);
+}
+
+TEST_F(RoutineControlTest, Rollback)
+{ 
+    EXPECT_EQ(routine_control->activateSoftware(), 0);
+}
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
-Unit tests for the Routine Control service partially fixed (65% line coverage, 88% function coverage). I couldn't increase the coverage further because some functions can only be tested with a properly configured environment, which I don't have.

## Trello link [here](https://trello.com/c/ZQslx79v/54-rework-tests-for-routine-control)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
