### PR TITLE
Solution for Upgrade Button bug

### DIFF
--- a/src/front_end/carsdata/src/components/OTAcomponents/UpgradeButton.tsx
+++ b/src/front_end/carsdata/src/components/OTAcomponents/UpgradeButton.tsx
@@ -76,7 +76,7 @@ const UpgradeButton = (props: any) => {
                 open={isVersionPopupVisible}
                 onCancel={() => setIsVersionPopupVisible(false)}
                 footer={props.softVersions.map((version: any, index: any) => (
-                    <Button className="m-1" key={version} onClick={() => updateToVersion(index)}>
+                    <Button className="m-1" key={'{version}-${index}'} onClick={() => updateToVersion(index)}>
                         {`Version ${version}`}
                     </Button>
                 ))}>


### PR DESCRIPTION
## Description
Issue: In the upgrade popup, the buttons for each version were not displayed correctly between units.

Cause: The issue was caused by the mapping over available versions array with a key (the sw_version) that was not unique. This led to a mix-up that displayed more buttons than necessary.

Solution: I also added the position in the array along the version name to make it more unique. Warnings are still displayed but the buttons are well made now. To ensure a complete solution, we will have to take into consideration using the version id along the version name because version names are not always unique.

## Trello link [here](https://trello.com/c/GEiYX3bN)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
