### PR TITLE
UTGenerateFramesFixed

### DIFF
--- a/src/utils/include/GenerateFrames.h
+++ b/src/utils/include/GenerateFrames.h
@@ -54,16 +54,6 @@ class GenerateFrames
          */
         int getSocket();
         /**
-         * @brief method to send response back to API
-         * 
-         * @param api_id identifier for the API that will send the frame.
-         * @param sid service id.
-         * @param battery_id id of the battery component.
-         * @param doors_id id of the doors component.
-         * @param engine_id id of the engine component.
-        */ 
-        void apiResponse(uint32_t api_id, uint8_t sid, uint8_t battery_id, uint8_t doors_id, uint8_t engine_id);
-        /**
          * @brief Method for creation of custom frames
          * 
          * @param id id of the frame

--- a/src/utils/src/GenerateFrames.cpp
+++ b/src/utils/src/GenerateFrames.cpp
@@ -78,11 +78,6 @@ int GenerateFrames::sendFrame(int can_id, std::vector<uint8_t> data, int s, Fram
     }
     return 0;
 }
-void GenerateFrames::apiResponse(uint32_t api_id, uint8_t sid, uint8_t battery_id, uint8_t doors_id, uint8_t engine_id)
-{
-    uint32_t can_id = (0x10 << 8) | api_id;
-    this->sendFrame(can_id, {0x06, sid, 0x10, battery_id, doors_id, engine_id});
-}
 void GenerateFrames::addSocket(int socket)
 {
     if (socket >= 0)


### PR DESCRIPTION
-Unit tests for Generate Frames service fixed (98.6% coverage)

## Trello link [here](https://trello.com/c/hBfGaYb2/57-rework-tests-for-generate-frames)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
