### PR TITLE
Integrated endpoints in Send Request Fragment

### DIFF
--- a/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/activities/UDSactivity.kt
+++ b/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/activities/UDSactivity.kt
@@ -193,7 +193,10 @@ class UDSactivity : ComponentActivity() {
                 ) {
                     DropdownMenuItem(
                         text = { Text(text = "Send requests") },
-                        onClick = {}
+                        onClick = {
+                            val intent = Intent(this@UDSactivity, RequestActivity::class.java)
+                            startActivity(intent)
+                        }
                     )
                 }
             },

--- a/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/fragments/Fragment_RequestSendAutomated.java
+++ b/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/fragments/Fragment_RequestSendAutomated.java
@@ -1,13 +1,38 @@
 package com.poc.p_couds.fragments;
 
 import android.annotation.SuppressLint;
+import android.content.DialogInterface;
 import android.os.Bundle;
+import android.text.method.ScrollingMovementMethod;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import androidx.fragment.app.Fragment;
-import com.poc.p_couds.R;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+import android.widget.Toast;
 
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.widget.SwitchCompat;
+import androidx.fragment.app.Fragment;
+
+import com.google.gson.Gson;
+import com.poc.p_couds.APIClient;
+import com.poc.p_couds.R;
+import com.poc.p_couds.models.IApiService;
+import com.poc.p_couds.pojo.Authenticate;
+import com.poc.p_couds.pojo.ChangeStatus;
+import com.poc.p_couds.pojo.ChangeStatusSession;
+import com.poc.p_couds.pojo.GetIdentifiers;
+import com.poc.p_couds.pojo.ReadAccesTiming;
+import com.poc.p_couds.pojo.ReadAccessTimingPost;
+import com.poc.p_couds.pojo.TesterPresent;
+import com.poc.p_couds.pojo.WriteTiming;
+import com.poc.p_couds.pojo.WriteTimingPost;
+
+import retrofit2.Call;
+import retrofit2.Response;
 
 
 /**
@@ -16,12 +41,237 @@ import com.poc.p_couds.R;
  * create an instance of this fragment.
  */
 public class Fragment_RequestSendAutomated extends Fragment {
+    private TextView testerTextView;
+    private IApiService apiInterface;
 
     @SuppressLint("SetTextI18n")
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_request_send_automated, container, false);
+        View view = inflater.inflate(R.layout.fragment_request_send_automated, container, false);
+        testerTextView = view.findViewById(R.id.response);
+        testerTextView.setMovementMethod(new ScrollingMovementMethod());
+
+        SwitchCompat switchCompatSession = view.findViewById(R.id.change_session);
+        switchCompatSession.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            int subFunct = isChecked ? 2 : 1;
+            ChangeStatusSession postBodySession = new ChangeStatusSession(subFunct);
+            toggleSession(postBodySession);
+            if (subFunct == 2) {
+                Toast.makeText(Fragment_RequestSendAutomated.this.getContext(), "PROGRAMMING SESSION", Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(Fragment_RequestSendAutomated.this.getContext(), "DEFAULT SESSION", Toast.LENGTH_SHORT).show();
+            }
+
+        });
+
+        Button authentication = view.findViewById(R.id.q3);
+        authentication.setOnClickListener(v -> callApiAuthentication());
+
+        Button readIdentifiers = view.findViewById(R.id.q4);
+        readIdentifiers.setOnClickListener(v -> callApiIdentifiers());
+
+        SwitchCompat switchCompatTester = view.findViewById(R.id.tester);
+        switchCompatTester.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if (isChecked) {
+                toggleTester();
+                Log.d("Toggle", "ON");
+            } else {
+                Log.d("Toggle", "OFF");
+            }
+        });
+        SwitchCompat switchCompatReadAccess = view.findViewById(R.id.read_access);
+        switchCompatReadAccess.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            int subFunct = isChecked ? 3 : 1; // If checked, subFunct = 3; else subFunct = 1
+
+            // Create the POST body object
+            ReadAccessTimingPost postBody = new ReadAccessTimingPost(subFunct);
+            toggleRead(postBody);
+        });
+
+        Button writeTimingP2Max = view.findViewById(R.id.q6);
+        writeTimingP2Max.setOnClickListener(v -> showInputDialogTiming());
+
+        return view;
+    }
+
+    private void toggleSession(ChangeStatusSession postBodySession){
+        apiInterface = APIClient.getClient().create(IApiService.class);
+
+        Call<ChangeStatus> call=apiInterface.requestChangeStatus(postBodySession);
+        call.enqueue(new retrofit2.Callback<ChangeStatus>() {
+            @Override
+            public void onResponse(Call<ChangeStatus> call, Response<ChangeStatus> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    Gson gson = new Gson();
+                    String jsonResponse = gson.toJson(response.body());
+                    testerTextView.setText(jsonResponse);
+                }
+                else {
+                    testerTextView.setText("Failed to retrive response");
+                }
+            }
+            @Override
+            public void onFailure(Call<ChangeStatus> call, Throwable t) {
+                testerTextView.setText("Request Failed: " + t);
+            }
+        });
+    }
+
+
+    private void callApiAuthentication() {
+        apiInterface = APIClient.getClient().create(IApiService.class);
+
+        Call<Authenticate> call=apiInterface.requestAuthenticate();
+        call.enqueue(new retrofit2.Callback<Authenticate>() {
+            @Override
+            public void onResponse(Call<Authenticate> call, Response<Authenticate> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    Gson gson = new Gson();
+                    String jsonResponse = gson.toJson(response.body());
+                    testerTextView.setText(jsonResponse);
+                }
+                else {
+                    testerTextView.setText("Failed to retrive response");
+                }
+            }
+            @Override
+            public void onFailure(Call<Authenticate> call, Throwable t) {
+                testerTextView.setText("Request Failed: " + t.getMessage());
+            }
+        });
+    }
+
+    private void callApiIdentifiers() {
+        apiInterface = APIClient.getClient().create(IApiService.class);
+
+        Call<GetIdentifiers> call = apiInterface.requestGetIdentifiers();
+        call.enqueue(new retrofit2.Callback<GetIdentifiers>() {
+            @Override
+            public void onResponse(Call<GetIdentifiers> call, Response<GetIdentifiers> response) {
+                if (response.isSuccessful() && response != null) {
+                    Gson gson = new Gson();
+                    String jsonResponse = gson.toJson(response.body());
+                    testerTextView.setText(jsonResponse);
+                } else {
+                    testerTextView.setText("Failed to retrieve response");
+                }
+            }
+            @Override
+            public void onFailure(Call<GetIdentifiers> call, Throwable t) {
+                testerTextView.setText("Request Failed: "+ t.getMessage());
+            }
+        });
+    }
+
+    private void toggleTester() {
+        apiInterface = APIClient.getClient().create(IApiService.class);
+        Call<TesterPresent> call = apiInterface.requestTesterPresent();
+        call.enqueue(new retrofit2.Callback<TesterPresent>() {
+            @Override
+            public void onResponse(Call<TesterPresent> call, Response<TesterPresent> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    Gson gson = new Gson();
+                    String jsonResponse = gson.toJson(response.body());
+                    testerTextView.setText(jsonResponse);
+                } else {
+                    testerTextView.setText("Failed to retrieve response.");
+                }
+            }
+
+            @Override
+            public void onFailure(Call<TesterPresent> call, Throwable t) {
+                testerTextView.setText("Request failed: " + t.getMessage());
+            }
+        });
+    }
+
+    private void toggleRead(ReadAccessTimingPost postBody) {
+        apiInterface = APIClient.getClient().create(IApiService.class);
+        Call<ReadAccesTiming> call = apiInterface.requestReadAccessTiming(postBody);
+        call.enqueue(new retrofit2.Callback<ReadAccesTiming>() {
+            @Override
+            public void onResponse(Call<ReadAccesTiming> call, Response<ReadAccesTiming> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    Gson gson = new Gson();
+                    String jsonResponse = gson.toJson(response.body());
+                    testerTextView.setText(jsonResponse);
+                } else {
+                    testerTextView.setText("Failed to retrieve response.");
+                }
+            }
+
+            @Override
+            public void onFailure(Call<ReadAccesTiming> call, Throwable t) {
+                testerTextView.setText("Request failed: " + t.getMessage());
+            }
+        });
+    }
+
+    private void showInputDialogTiming() {
+        LayoutInflater inflater = LayoutInflater.from(requireContext());
+        View dialogView = inflater.inflate(R.layout.dialog_input_p2time, null);
+
+        EditText editTextP2MaxTime = dialogView.findViewById(R.id.editTextP2MaxTime);
+        EditText editTextP2StarTime = dialogView.findViewById(R.id.editTextP2StarMaxTime);
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(requireContext());
+        builder.setTitle("P2 Timing Values");
+        builder.setView(dialogView);
+
+        builder.setPositiveButton("Submit", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                String p2MaxTimeStr = editTextP2MaxTime.getText().toString();
+                String p2StarTimeStr = editTextP2StarTime.getText().toString();
+                ;
+
+                if (!p2MaxTimeStr.isEmpty() && !p2StarTimeStr.isEmpty()) {
+                    try {
+                        // Convert to integers
+                        int p2MaxTime = Integer.parseInt(p2MaxTimeStr);
+                        int p2StarTime = Integer.parseInt(p2StarTimeStr);
+
+                        // Call the API with integer values
+                        callApiWithCustomTiming(p2MaxTime, p2StarTime);
+                    } catch (NumberFormatException e) {
+                        // Show an error message for invalid integer input
+                        testerTextView.setText("Please enter valid integer values.");
+                    }
+                } else {
+                    testerTextView.setText("Please enter values for both fields.");
+                }
+            }
+        });
+        builder.setNegativeButton("Cancel", null);
+        builder.create().show();
+    }
+
+    private void callApiWithCustomTiming(int p2MaxTime, int p2StarTime) {
+        apiInterface = APIClient.getClient().create(IApiService.class);
+
+        WriteTimingPost postBody = new WriteTimingPost(p2MaxTime, p2StarTime);
+
+        Call<WriteTiming> call= apiInterface.requestWriteTiming(postBody);
+        call.enqueue(new retrofit2.Callback<WriteTiming>() {
+            @Override
+            public void onResponse(Call<WriteTiming> call, Response<WriteTiming> response){
+                if (response.isSuccessful() && response.body() != null) {
+                    Gson gson = new Gson();
+                    String jsonResponse = gson.toJson(response.body());
+
+                    testerTextView.setText(jsonResponse);
+                }
+                else {
+                    testerTextView.setText("Failed to retrieve the response.");
+                }
+            }
+
+            @Override
+            public void onFailure(Call<WriteTiming> call, Throwable t) {
+                testerTextView.setText("Request failed: " + t.getMessage());
+            }
+        });
     }
 }

--- a/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/models/DbHelper.java
+++ b/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/models/DbHelper.java
@@ -38,7 +38,6 @@ public class DbHelper extends SQLiteOpenHelper {
                 + ARTIFACT_COL + " TEXT PRIMARY KEY UNIQUE, "
                 + STATUS_COL + " TEXT, "
                 + START_TIME_COL + " TEXT, "
-                + START_TIME_COL + " TEXT, "
                 + SIZE_COL + " TEXT)";
         sqLiteDatabase.execSQL(query);
     }

--- a/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/models/IApiService.kt
+++ b/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/models/IApiService.kt
@@ -7,6 +7,7 @@ import com.poc.p_couds.pojo.WriteHvacResponseDataClass
 import com.poc.p_couds.pojo.Authenticate
 import com.poc.p_couds.pojo.BatteryDataClass
 import com.poc.p_couds.pojo.ChangeStatus
+import com.poc.p_couds.pojo.ChangeStatusSession
 import com.poc.p_couds.pojo.DoorsDataClass
 import com.poc.p_couds.pojo.ECU
 import com.poc.p_couds.pojo.EngineDataClass
@@ -23,6 +24,8 @@ import com.poc.p_couds.pojo.UpdateHistory
 import com.poc.p_couds.pojo.UpdateV
 import com.poc.p_couds.pojo.UpdateVResponse
 import com.poc.p_couds.pojo.VINResponse
+import com.poc.p_couds.pojo.WriteTiming
+import com.poc.p_couds.pojo.WriteTimingPost
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.http.Body
@@ -83,8 +86,8 @@ interface IApiService {
     @GET("/api/history_updates")
     fun requestListOfUpdatesHistory(): Call<List<UpdateHistory>>
 
-    @GET("/api/change_session")
-    fun requestChangeStatus(): Call<ChangeStatus>
+    @POST("/api/change_session")
+    fun requestChangeStatus(@Body changeStatusSession: ChangeStatusSession): Call<ChangeStatus>
 
     @GET("/api/read_dtc_info")
     fun requestReadDtcInfo(): Call<ReadDtc>
@@ -103,4 +106,7 @@ interface IApiService {
 
     @GET("/api/get_identifiers")
     fun requestGetIdentifiers(): Call<GetIdentifiers>
+
+    @POST("/api/write_timing")
+    fun requestWriteTiming(@Body writeTimingPost: WriteTimingPost): Call<WriteTiming>
 }

--- a/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/pojo/ChangeStatusSession.java
+++ b/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/pojo/ChangeStatusSession.java
@@ -1,0 +1,13 @@
+package com.poc.p_couds.pojo;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ChangeStatusSession {
+    @SerializedName("sub_funct")
+    private int subFunct;
+
+    public ChangeStatusSession(int subFunct)
+    {
+        this.subFunct = subFunct;
+    }
+}

--- a/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/pojo/GetIdentifiers.java
+++ b/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/pojo/GetIdentifiers.java
@@ -6,9 +6,9 @@ public class GetIdentifiers {
     @SerializedName("Battery_Identifiers")
     private BatteryIdentifiers batteryIdentifiers;
     @SerializedName("Doors_Identifiers")
-    private String doorsIdentifiers;
+    private DoorsIdentifiers doorsIdentifiers;
     @SerializedName("Engine_Identifiers")
-    private String engineIdentifiers;
+    private EngineIdentifiers engineIdentifiers;
     @SerializedName("MCU_Identifiers")
     private McuIdentifiers mcuIdentifiers;
 
@@ -38,6 +38,97 @@ public class GetIdentifiers {
             return voltage;
         }
     }
+
+    public static class DoorsIdentifiers{
+        @SerializedName("ajar")
+        private String ajar;
+        @SerializedName("door")
+        private String door;
+        @SerializedName("driver")
+        private String driver;
+        @SerializedName("passenger")
+        private String passenger;
+        @SerializedName("passenger_lock")
+        private String passengerLock;
+
+        public String getAjarStatus() {
+            return ajar;
+        }
+
+        public String getDoorStatus() {
+            return door;
+        }
+
+        public String getDriverStatus() {
+            return driver;
+        }
+
+        public String getPassengerStatus() {
+            return passenger;
+        }
+
+        public String getPassengerLockStatus() {
+            return passengerLock;
+        }
+    }
+
+    public static class EngineIdentifiers{
+        @SerializedName("coolant_temperature")
+        private String coolantTemperature;
+        @SerializedName("engine_load")
+        private String engineLoad;
+        @SerializedName("engine_rpm")
+        private String engineRpm;
+        @SerializedName("fuel_level")
+        private String fuelLevel;
+        @SerializedName("fuel_pressure")
+        private String fuelPressure;
+        @SerializedName("intake_air_temperature")
+        private String intakeAirTemperature;
+        @SerializedName("oil_temperature")
+        private String oilTemperature;
+        @SerializedName("throttle_position")
+        private String throttlePosition;
+        @SerializedName("vehicle_speed")
+        private String vehicleSpeed;
+
+        public String getCoolantTemperatureStatus() {
+            return coolantTemperature;
+        }
+
+        public String getEngineLoadStatus() {
+            return engineLoad;
+        }
+
+        public String getEngineRpmStatus() {
+            return engineRpm;
+        }
+
+        public String getFuelLevelStatus() {
+            return fuelLevel;
+        }
+
+        public String getFuelPressureStatus() {
+            return fuelPressure;
+        }
+
+        public String getIntakeAirTemperatureStatus() {
+            return intakeAirTemperature;
+        }
+
+        public String getOilTemperatureStatus() {
+            return oilTemperature;
+        }
+
+        public String getThrottlePositionStatus() {
+            return throttlePosition;
+        }
+
+        public String getVehicleSpeedStatus() {
+            return vehicleSpeed;
+        }
+    }
+
     public static class McuIdentifiers{
         @SerializedName("ecu_hardware_number")
         private String ecuHardwareNumber;
@@ -105,11 +196,11 @@ public class GetIdentifiers {
         return batteryIdentifiers;
     }
 
-    public String getDoorsIdentifiers() {
+    public DoorsIdentifiers getDoorsIdentifiers() {
         return doorsIdentifiers;
     }
 
-    public String getEngineIdentifiers() {
+    public EngineIdentifiers getEngineIdentifiers() {
         return engineIdentifiers;
     }
 

--- a/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/pojo/WriteTiming.java
+++ b/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/pojo/WriteTiming.java
@@ -2,38 +2,33 @@ package com.poc.p_couds.pojo;
 
 import com.google.gson.annotations.SerializedName;
 
-public class ReadAccesTiming {
+public class WriteTiming {
     @SerializedName("message")
     private String message;
 
     @SerializedName("status")
     private String status;
 
-    @SerializedName("timing_values")
+    @SerializedName("written_values")
     private TimingValue timingValue;
 
     public static class TimingValue
     {
         // For subFunct = 3 (custom values)
-        @SerializedName("p2_max_time")
+        @SerializedName("New P2 Max Time")
         private String p2Max;
 
-        @SerializedName("p2_star_max_time")
+        @SerializedName("New P2 Star Max")
         private String p2Star;
 
-        @SerializedName("P2_MAX_TIME_DEFAULT")
-        private String p2MaxDefault;
-
-        @SerializedName("P2_STAR_MAX_TIME_DEFAULT")
-        private String p2StarDefault;
 
         public String getP2Max()
         {
-            return p2Max != null ? p2Max: p2MaxDefault;
+            return p2Max;
         }
         public String getP2Star()
         {
-            return p2Star != null ? p2Star: p2StarDefault;
+            return p2Star;
         }
     }
     public String getMessage()

--- a/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/pojo/WriteTimingPost.java
+++ b/src/android_app/CarsData/app/src/main/java/com/poc/p_couds/pojo/WriteTimingPost.java
@@ -1,0 +1,14 @@
+package com.poc.p_couds.pojo;
+
+import com.google.gson.annotations.SerializedName;
+
+public class WriteTimingPost {
+    @SerializedName("p2_max") private int p2max;
+    @SerializedName("p2_star_max") private int p2star;
+
+    public WriteTimingPost(int p2max, int p2star)
+    {
+        this.p2max = p2max;
+        this.p2star = p2star;
+    }
+}

--- a/src/android_app/CarsData/app/src/main/res/layout/dialog_input_p2time.xml
+++ b/src/android_app/CarsData/app/src/main/res/layout/dialog_input_p2time.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/editTextP2MaxTime"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Enter P2 Max Time"
+        android:inputType="text"
+        android:paddingTop="20dp"/>
+
+    <EditText
+        android:id="@+id/editTextP2StarMaxTime"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Enter P2 Star Max Time"
+        android:inputType="text"
+        android:paddingTop="20dp"/>
+</LinearLayout>

--- a/src/android_app/CarsData/app/src/main/res/layout/fragment_request_send_automated.xml
+++ b/src/android_app/CarsData/app/src/main/res/layout/fragment_request_send_automated.xml
@@ -38,6 +38,7 @@
                     android:layout_height="wrap_content"
                     android:text="@string/tester_present"/>
                 <androidx.appcompat.widget.SwitchCompat
+                    android:id="@id/change_session"
                     android:layout_width="105dp"
                     android:layout_height="wrap_content"
                     android:text="@string/session"/>

--- a/src/android_app/CarsData/app/src/main/res/values/ids.xml
+++ b/src/android_app/CarsData/app/src/main/res/values/ids.xml
@@ -9,4 +9,5 @@
     <item name="tester" type="id"/>
     <item name="response" type="id"/>
     <item name="read_access" type="id"/>
+    <item name="change_session" type="id"/>
 </resources>


### PR DESCRIPTION
## Description

Integrated Tester Present, Read Access Timing, Write Timing endpoints, Session, Authentication, Read Identifiers in Fragment Semi-Automated
Fixed missing Intent in UDS and duplicate line in DBHelper

Files added:
ChangeStatusSession -pojo
writeTiming -pojo
writeTimingPost -pojo
dialog_input_p2time.xml -layout

Modified:
GetIdinetifiers -pojo
IApiService -models
ReadAccessTiming -pojo
Fragment_RequestSendAutomated -fragments
ApiClient

## Trello link [here](https://trello.com/c/R3jSgdRG/22-integrate-tester-present-read-access-timing-and-write-timing-endpoints)
## Trello link [here](https://trello.com/c/0KuNVNuY/24-integrate-authentication-session-and-read-identifiers-api-endpoints-in-semi-automated-request-fragment)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
