### PR TITLE
CreatedECUTest&ResolveReadValueBug

### DIFF
--- a/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
+++ b/src/ecu_simulation/BatteryModule/src/BatteryModule.cpp
@@ -72,17 +72,46 @@ void BatteryModule::parseBatteryInfo(const std::string &data, float &energy, flo
         if (line.find("energy:") != std::string::npos)
         {
             energy = std::stof(line.substr(line.find(":") + 1));
-            updated_values[0x01A0] = std::to_string(static_cast<uint8_t>(energy));
+            uint8_t energy_value = static_cast<uint8_t>(energy);
+            std::string energy_str = std::to_string(energy_value);
+            /* Add a leading '0' if the string length is odd to ensure pairs of two characters */
+            if (energy_str.size() % 2 != 0) {
+                energy_str = "0" + energy_str;
+            }
+            /* Group characters in pairs of two with a space separator */
+            std::string energy_grouped;
+            for (size_t i = 0; i < energy_str.size(); i += 2) {
+                energy_grouped += energy_str.substr(i, 2) + " ";
+            }
+            updated_values[0x01A0] = energy_grouped;
         }
         else if (line.find("voltage:") != std::string::npos)
         {
             voltage = std::stof(line.substr(line.find(":") + 1));
-            updated_values[0x01B0] = std::to_string(static_cast<uint8_t>(voltage));
+            uint8_t voltage_value = static_cast<uint8_t>(voltage);
+            std::string voltage_str = std::to_string(voltage_value);
+            if (voltage_str.size() % 2 != 0) {
+                voltage_str = "0" + voltage_str;
+            }
+            std::string voltage_grouped;
+            for (size_t i = 0; i < voltage_str.size(); i += 2) {
+                voltage_grouped += voltage_str.substr(i, 2) + " ";
+            }
+            updated_values[0x01B0] = voltage_grouped;
         }
         else if (line.find("percentage:") != std::string::npos)
         {
             percentage = std::stof(line.substr(line.find(":") + 1));
-            updated_values[0x01C0] = std::to_string(static_cast<uint8_t>(percentage));
+            uint8_t percentage_value = static_cast<uint8_t>(percentage);
+            std::string percentage_str = std::to_string(percentage_value);
+            if (percentage_str.size() % 2 != 0) {
+                percentage_str = "0" + percentage_str;
+            }
+            std::string percentage_grouped;
+            for (size_t i = 0; i < percentage_str.size(); i += 2) {
+                percentage_grouped += percentage_str.substr(i, 2) + " ";
+            }
+            updated_values[0x01C0] = percentage_grouped;
         }
         else if (line.find("state:") != std::string::npos)
         {

--- a/src/mcu/Makefile
+++ b/src/mcu/Makefile
@@ -217,8 +217,7 @@ MCU_OBJS_TEST = $(OBJ_DIR)/MCUModule_test.o \
 ECU_OBJS_TEST = $(OBJ_DIR)/BatteryModule_test.o \
                 $(OBJ_DIR)/EngineModule_test.o \
                 $(OBJ_DIR)/DoorsModule_test.o \
-                $(OBJ_DIR)/HVACModule_test.o \
-                $(OBJ_DIR)/ECU_test.o
+                $(OBJ_DIR)/HVACModule_test.o
 
 UTILS_OBJS_TEST = $(OBJ_DIR)/MemoryManager_test.o \
                   $(OBJ_DIR)/Logger_test.o \
@@ -227,6 +226,7 @@ UTILS_OBJS_TEST = $(OBJ_DIR)/MemoryManager_test.o \
                   $(OBJ_DIR)/NegativeResponse_test.o \
                   $(OBJ_DIR)/HandleFrames_test.o \
 				  $(OBJ_DIR)/ReceiveFrames_test_utils.o \
+				  $(OBJ_DIR)/ECU_test.o \
                   $(OBJ_DIR)/FileManager_test.o
 
 OBJS_GENERATE_TEST = $(OBJ_DIR)/Logger_test.o \
@@ -421,7 +421,7 @@ $(OBJ_DIR)/NegativeResponse_test.o: $(UTILS_DIR)/NegativeResponse.cpp
 	
 # Compile all unit tests
 
-allTests: mcuModuleTest handleFramesTest receiveFramesTest generateFramesTest loggerTest memoryManagerTest createInterfaceTest diagnosticSessionControlTest writeDataByIdentifierTest readDataByIdentifierTest requestTransferExitTest readDtcTest clearDtcTest requestUpdateStatusTest securityAccessTest testerPresentTest routineControlTest transferDataTest requestDownloadTest ecuResetTest negativeResponseTest accessTimingParameterTest receiveFramesTestUtils
+allTests: mcuModuleTest handleFramesTest receiveFramesTest generateFramesTest loggerTest memoryManagerTest createInterfaceTest diagnosticSessionControlTest writeDataByIdentifierTest readDataByIdentifierTest requestTransferExitTest readDtcTest clearDtcTest requestUpdateStatusTest securityAccessTest testerPresentTest routineControlTest transferDataTest requestDownloadTest ecuResetTest negativeResponseTest accessTimingParameterTest receiveFramesTestUtils ecuTest
 
 
 # HandleFrames Unit tests
@@ -432,6 +432,24 @@ $(UTILS_TEST)/handleFramesTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UTILS_TEST)/Handle
 
 $(UTILS_TEST)/HandleFrames_test.o: $(UTILS_TEST)/HandleFramesTest.cpp
 	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UTILS_TEST)/HandleFramesTest.cpp -o $(UTILS_TEST)/HandleFrames_test.o $(CFLAGSTST2) $(LDFLAGS)
+
+# ECU Unit tests
+ecuTest: $(OBJ_DIR) $(UTILS_TEST)/ecuTest.out
+
+$(UTILS_TEST)/ecuTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UTILS_TEST)/ECU_test.o
+	$(CXX) $(CFLAGSTST) -o $(UTILS_TEST)/ecuTest.out $(UTILS_TEST)/ECU_test.o $(OBJS_TEST) $(CFLAGSTST2) $(LDFLAGS)
+
+$(UTILS_TEST)/ECU_test.o: $(UTILS_TEST)/ECUTest.cpp
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UTILS_TEST)/ECUTest.cpp -o $(UTILS_TEST)/ECU_test.o $(CFLAGSTST2) $(LDFLAGS)
+
+# ECU Unit tests
+ecuTest: $(OBJ_DIR) $(UTILS_TEST)/ecuTest.out
+
+$(UTILS_TEST)/ecuTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UTILS_TEST)/ECU_test.o
+	$(CXX) $(CFLAGSTST) -o $(UTILS_TEST)/ecuTest.out $(UTILS_TEST)/ECU_test.o $(OBJS_TEST) $(CFLAGSTST2) $(LDFLAGS)
+
+$(UTILS_TEST)/ECU_test.o: $(UTILS_TEST)/ECU.cpp
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UTILS_TEST)/ECU.cpp -o $(UTILS_TEST)/ECU_test.o $(CFLAGSTST2) $(LDFLAGS)
 
 # ReceiveFramesUtils Unit tests
 receiveFramesTestUtils: $(OBJ_DIR) $(UTILS_TEST)/receiveFramesTestUtils.out
@@ -911,6 +929,20 @@ handleFrames_coverage: handleFramesTest
 	gcov -o obj/HandleFrames_test.gcno obj/HandleFrames_test.gcda $(UTILS_TEST)/HandleFrames.cpp
 	mv HandleFrames.cpp.gcov coverage/out_HandleFrames
 
+# ECU Coverage - solo job
+ecuCoverage: ecu_coverage
+	lcov --capture --directory . --output-file coverage.info
+	lcov --remove coverage.info '/usr/' --output-file coverage_filtered.info
+	lcov --remove coverage.info '/test/' --output-file coverage.info
+	genhtml coverage_filtered.info --output-directory coverage/out_ECUTest
+	xdg-open coverage/out_ECUTest/index.html
+# This job runs for allCoverage
+ecu_coverage: ecuTest
+	./$(UTILS_TEST)/ecuTest.out
+	mkdir -p coverage/out_ECU
+	gcov -o obj/ECU_test.gcno obj/ECU_test.gcda $(UTILS_TEST)/ECU.cpp
+	mv ECU.cpp.gcov coverage/out_ECU
+
 # ReceiveFramesUtils Coverage - solo job
 receiveFramesCoverageUtils: receiveFrames_coverage_utils
 	lcov --capture --directory . --output-file coverage.info
@@ -1149,7 +1181,7 @@ batteryModule_coverage: batteryModuleTest
 
 
 
-allCoverage: securityAccess_coverage routineControl_coverage transferData_coverage requestDownload_coverage ecuReset_coverage memoryManager_coverage logger_coverage generateFrames_coverage mcuModule_coverage receiveFrames_coverage handleFrames_coverage createInterface_coverage diagnosticSessionControl_coverage writeDataByIdentifier_coverage readDataByIdentifier_coverage testerPresent_coverage requestTransferExit_coverage clearDtc_coverage readDtc_coverage requestUpdateStatus_coverage negativeResponse_coverage accessTimingParameter_coverage receiveFrames_coverage_utils
+allCoverage: securityAccess_coverage routineControl_coverage transferData_coverage requestDownload_coverage ecuReset_coverage memoryManager_coverage logger_coverage generateFrames_coverage mcuModule_coverage receiveFrames_coverage handleFrames_coverage createInterface_coverage diagnosticSessionControl_coverage writeDataByIdentifier_coverage readDataByIdentifier_coverage testerPresent_coverage requestTransferExit_coverage clearDtc_coverage readDtc_coverage requestUpdateStatus_coverage negativeResponse_coverage accessTimingParameter_coverage receiveFrames_coverage_utils ecu_coverage
 
 
 allCoveragePostProcess:

--- a/src/utils/test/ECUTest.cpp
+++ b/src/utils/test/ECUTest.cpp
@@ -1,0 +1,155 @@
+
+#include <cstring>
+#include <string>
+#include <thread>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <gtest/gtest.h>
+#include <net/if.h>
+
+#include "../include/ECU.h"
+#include "../include/GenerateFrames.h"
+
+int socket1;
+int socket2;
+
+class CaptureFrame
+{
+    public:
+        struct can_frame frame;
+        void capture()
+        {
+            read(socket1, &frame, sizeof(struct can_frame));
+        }
+};
+
+struct ECUTest : testing::Test
+{
+    Logger* logger;
+    ECU* ecu;
+    CaptureFrame* c1;
+    GenerateFrames* g;
+    ECUTest()
+    {
+        logger = new Logger();
+        ecu = new ECU(0x11, *logger);
+        c1 = new CaptureFrame();
+        g = new GenerateFrames(socket1, *logger);
+    }
+    ~ECUTest()
+    {
+        delete ecu;
+        delete g;
+        delete c1;
+        delete logger;
+    }
+};
+
+int createSocket()
+{
+    /* Create socket */
+    std::string name_interface = "vcan0";
+    struct sockaddr_can addr;
+    struct ifreq ifr;
+    int s;
+
+    s = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+    if (s < 0)
+    {
+        std::cout<<"Error trying to create the socket\n";
+        return 1;
+    }
+    /* Giving name and index to the interface created */
+    strcpy(ifr.ifr_name, name_interface.c_str() );
+    ioctl(s, SIOCGIFINDEX, &ifr);
+    /* Set addr structure with info. of the CAN interface */
+    addr.can_family = AF_CAN;
+    addr.can_ifindex = ifr.ifr_ifindex;
+    /* Bind the socket to the CAN interface */
+    int b = bind(s, (struct sockaddr*)&addr, sizeof(addr));
+    if( b < 0 )
+    {
+        std::cout<<"Error binding\n";
+        return 1;
+    }
+    int flags = fcntl(s, F_GETFL, 0);
+    if (flags == -1)
+    {
+        return 1;
+    }
+    /* Set the O_NONBLOCK flag to make the socket non-blocking */
+    flags |= O_NONBLOCK;
+    if (fcntl(s, F_SETFL, flags) == -1)
+    {
+        return -1;
+    }
+    return s;
+}
+
+void testFrames(struct can_frame expected_frame, CaptureFrame &c1 )
+{
+    EXPECT_EQ(expected_frame.can_id & 0xFFFF, c1.frame.can_id & 0xFFFF);
+    EXPECT_EQ(expected_frame.can_dlc, c1.frame.can_dlc);
+    for (int i = 0; i < expected_frame.can_dlc; ++i)
+    {
+        EXPECT_EQ(expected_frame.data[i], c1.frame.data[i]);
+    }
+}
+
+struct can_frame createFrame(uint16_t can_id ,std::vector<uint8_t> test_data)
+{
+    struct can_frame result_frame;
+    result_frame.can_id = can_id;
+    int i=0;
+    for (auto d : test_data)
+    {
+        result_frame.data[i++] = d;
+    }
+    result_frame.can_dlc = test_data.size();
+    return result_frame;
+}
+
+TEST_F(ECUTest, NotificationToMcu)
+{
+    std::cerr << "Running NotificationToMcu" << std::endl;
+
+    struct can_frame result_frame = createFrame(0x1110, {0x01, 0xD9});
+    ecu->sendNotificationToMCU();
+    c1->capture();
+    testFrames(result_frame, *c1);
+
+    std::cerr << "Finished NotificationToMcu" << std::endl;
+}
+
+TEST_F(ECUTest, StartFrames)
+{
+    std::cerr << "Running StartFrames" << std::endl;
+
+    testing::internal::CaptureStdout();
+    std::thread processor_thread([this] {
+        ecu->startFrames();
+    });
+    ecu->stopFrames();
+    processor_thread.join();
+    std::string output = testing::internal::GetCapturedStdout();
+    EXPECT_NE(output.find("11 starts the frame receiver"), std::string::npos);
+
+    std::cerr << "Finished StartFrames" << std::endl;
+}
+
+int main(int argc, char* argv[])
+{
+    socket1 = createSocket();
+    socket2 = createSocket();
+    testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+    if (socket1 > 0)
+    {
+        close(socket1);
+    }
+    if (socket2 > 0)
+    {
+        close(socket2);
+    }
+    return result;
+}


### PR DESCRIPTION
- Create tests for the ECU class with 100% coverage
- Fix the bug: 'Read from file not working properly for values longer than 1 byte'

## Trello link to test [here](https://trello.com/c/6ketJADl/39-create-tests-for-ecucpp)
## Trello link to bug [here](https://trello.com/c/G5uhW8Hv/29-backendmedium-read-from-file-not-properly-work-for-values-on-more-than-1-byte)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
