### PR TITLE
Bug fix - infinite requests between mcu-ecu

### DIFF
--- a/src/utils/src/HandleFrames.cpp
+++ b/src/utils/src/HandleFrames.cpp
@@ -27,15 +27,14 @@ void HandleFrames::handleFrame(int can_socket, const struct can_frame &frame)
     /* id < 0x10 == single frame*/
     if (frame.data[0] < 0x10) 
     {
-        /* if frame is negative response, 0x7F takes sid's place so sid comes next to it */
+        /* if frame is negative response, return */
         if (frame.data[1] == 0x7F)
         {
-            sid = frame.data[2];
+            LOG_INFO(_logger.GET_LOGGER(), "Negative response received.");
+            return;
         }
-        else
-        {
-            sid = frame.data[1];  
-        }
+
+        sid = frame.data[1];  
         LOG_INFO(_logger.GET_LOGGER(), "Single Frame received:");
         for (uint8_t data_pos = 0; data_pos < frame.can_dlc; ++data_pos) 
         {


### PR DESCRIPTION
## Description

Fixed bug when a request between mcu-ecu was made and a nrc was received. The nrc response was interpreted as another service request and so on..

## Trello link [here](https://trello.com/c/0gzRQiq4/34-backendmajor-infinite-frame-sending-loop-between-ecu-mcu)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
